### PR TITLE
Minor tweaks

### DIFF
--- a/6-jre-1.7.2-jaxrs/Dockerfile
+++ b/6-jre-1.7.2-jaxrs/Dockerfile
@@ -5,14 +5,28 @@ RUN mkdir -p /usr/local/tomee
 
 WORKDIR /usr/local/tomee
 
-RUN curl -SL http://www.apache.org/dist/tomee/KEYS -o KEYS \
-	&& gpg --import KEYS
+# curl -fsSL 'https://www.apache.org/dist/tomee/KEYS' | awk -F ' = ' '$1 ~ /^ +Key fingerprint$/ { gsub(" ", "", $2); print $2 }' | sort -u
+ENV GPG_KEYS \
+	223D3A74B068ECA354DC385CE126833F9CF64915 \
+	7A2744A8A9AAF063C23EB7868EBE7DBE8D050EEF \
+	82D8419BA697F0E7FB85916EE91287822FDB81B1 \
+	9056B710F1E332780DE7AF34CBAEBE39A46C4CA1 \
+	A57DAF81C1B69921F4BA8723A8DE0A4DB863A7C1 \
+	B7574789F5018690043E6DD9C212662E12F3E1DD \
+	B8B301E6105DF628076BD92C5483E55897ABD9B9 \
+	DBCCD103B8B24F86FFAAB025C8BB472CD297D428 \
+	F067B8140F5DD80E1D3B5D92318242FE9A0B1183 \
+	FAA603D58B1BA4EDF65896D0ED340E0E6D545F97
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
-RUN curl -SL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-jaxrs.tar.gz.asc -o tomee.tar.gz.asc
-
-RUN curl -SL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-jaxrs.tar.gz -o tomee.tar.gz \
-	&& tar -zxvf tomee.tar.gz  \
+RUN set -x \
+	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-jaxrs.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-jaxrs.tar.gz -o tomee.tar.gz \
 	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-jaxrs-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-jaxrs-1.7.2 \
 	&& rm bin/*.bat \

--- a/6-jre-1.7.2-plume/Dockerfile
+++ b/6-jre-1.7.2-plume/Dockerfile
@@ -5,14 +5,28 @@ RUN mkdir -p /usr/local/tomee
 
 WORKDIR /usr/local/tomee
 
-RUN curl -SL http://www.apache.org/dist/tomee/KEYS -o KEYS \
-	&& gpg --import KEYS
+# curl -fsSL 'https://www.apache.org/dist/tomee/KEYS' | awk -F ' = ' '$1 ~ /^ +Key fingerprint$/ { gsub(" ", "", $2); print $2 }' | sort -u
+ENV GPG_KEYS \
+	223D3A74B068ECA354DC385CE126833F9CF64915 \
+	7A2744A8A9AAF063C23EB7868EBE7DBE8D050EEF \
+	82D8419BA697F0E7FB85916EE91287822FDB81B1 \
+	9056B710F1E332780DE7AF34CBAEBE39A46C4CA1 \
+	A57DAF81C1B69921F4BA8723A8DE0A4DB863A7C1 \
+	B7574789F5018690043E6DD9C212662E12F3E1DD \
+	B8B301E6105DF628076BD92C5483E55897ABD9B9 \
+	DBCCD103B8B24F86FFAAB025C8BB472CD297D428 \
+	F067B8140F5DD80E1D3B5D92318242FE9A0B1183 \
+	FAA603D58B1BA4EDF65896D0ED340E0E6D545F97
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
-RUN curl -SL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-plume.tar.gz.asc -o tomee.tar.gz.asc
-
-RUN curl -SL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-plume.tar.gz -o tomee.tar.gz \
-	&& tar -zxvf tomee.tar.gz  \
+RUN set -x \
+	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-plume.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-plume.tar.gz -o tomee.tar.gz \
 	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plume-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plume-1.7.2 \
 	&& rm bin/*.bat \

--- a/6-jre-1.7.2-plus/Dockerfile
+++ b/6-jre-1.7.2-plus/Dockerfile
@@ -5,14 +5,28 @@ RUN mkdir -p /usr/local/tomee
 
 WORKDIR /usr/local/tomee
 
-RUN curl -SL http://www.apache.org/dist/tomee/KEYS -o KEYS \
-	&& gpg --import KEYS
+# curl -fsSL 'https://www.apache.org/dist/tomee/KEYS' | awk -F ' = ' '$1 ~ /^ +Key fingerprint$/ { gsub(" ", "", $2); print $2 }' | sort -u
+ENV GPG_KEYS \
+	223D3A74B068ECA354DC385CE126833F9CF64915 \
+	7A2744A8A9AAF063C23EB7868EBE7DBE8D050EEF \
+	82D8419BA697F0E7FB85916EE91287822FDB81B1 \
+	9056B710F1E332780DE7AF34CBAEBE39A46C4CA1 \
+	A57DAF81C1B69921F4BA8723A8DE0A4DB863A7C1 \
+	B7574789F5018690043E6DD9C212662E12F3E1DD \
+	B8B301E6105DF628076BD92C5483E55897ABD9B9 \
+	DBCCD103B8B24F86FFAAB025C8BB472CD297D428 \
+	F067B8140F5DD80E1D3B5D92318242FE9A0B1183 \
+	FAA603D58B1BA4EDF65896D0ED340E0E6D545F97
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
-RUN curl -SL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-plus.tar.gz.asc -o tomee.tar.gz.asc
-
-RUN curl -SL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-plus.tar.gz -o tomee.tar.gz \
-	&& tar -zxvf tomee.tar.gz  \
+RUN set -x \
+	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-plus.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-plus.tar.gz -o tomee.tar.gz \
 	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plus-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plus-1.7.2 \
 	&& rm bin/*.bat \

--- a/6-jre-1.7.2-webprofile/Dockerfile
+++ b/6-jre-1.7.2-webprofile/Dockerfile
@@ -5,14 +5,28 @@ RUN mkdir -p /usr/local/tomee
 
 WORKDIR /usr/local/tomee
 
-RUN curl -SL http://www.apache.org/dist/tomee/KEYS -o KEYS \
-	&& gpg --import KEYS
+# curl -fsSL 'https://www.apache.org/dist/tomee/KEYS' | awk -F ' = ' '$1 ~ /^ +Key fingerprint$/ { gsub(" ", "", $2); print $2 }' | sort -u
+ENV GPG_KEYS \
+	223D3A74B068ECA354DC385CE126833F9CF64915 \
+	7A2744A8A9AAF063C23EB7868EBE7DBE8D050EEF \
+	82D8419BA697F0E7FB85916EE91287822FDB81B1 \
+	9056B710F1E332780DE7AF34CBAEBE39A46C4CA1 \
+	A57DAF81C1B69921F4BA8723A8DE0A4DB863A7C1 \
+	B7574789F5018690043E6DD9C212662E12F3E1DD \
+	B8B301E6105DF628076BD92C5483E55897ABD9B9 \
+	DBCCD103B8B24F86FFAAB025C8BB472CD297D428 \
+	F067B8140F5DD80E1D3B5D92318242FE9A0B1183 \
+	FAA603D58B1BA4EDF65896D0ED340E0E6D545F97
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
-RUN curl -SL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-webprofile.tar.gz.asc -o tomee.tar.gz.asc
-
-RUN curl -SL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-webprofile.tar.gz -o tomee.tar.gz \
-	&& tar -zxvf tomee.tar.gz  \
+RUN set -x \
+	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-webprofile.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-webprofile.tar.gz -o tomee.tar.gz \
 	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-webprofile-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-webprofile-1.7.2 \
 	&& rm bin/*.bat \

--- a/7-jre-1.7.2-jaxrs/Dockerfile
+++ b/7-jre-1.7.2-jaxrs/Dockerfile
@@ -5,14 +5,28 @@ RUN mkdir -p /usr/local/tomee
 
 WORKDIR /usr/local/tomee
 
-RUN curl -SL http://www.apache.org/dist/tomee/KEYS -o KEYS \
-	&& gpg --import KEYS
+# curl -fsSL 'https://www.apache.org/dist/tomee/KEYS' | awk -F ' = ' '$1 ~ /^ +Key fingerprint$/ { gsub(" ", "", $2); print $2 }' | sort -u
+ENV GPG_KEYS \
+	223D3A74B068ECA354DC385CE126833F9CF64915 \
+	7A2744A8A9AAF063C23EB7868EBE7DBE8D050EEF \
+	82D8419BA697F0E7FB85916EE91287822FDB81B1 \
+	9056B710F1E332780DE7AF34CBAEBE39A46C4CA1 \
+	A57DAF81C1B69921F4BA8723A8DE0A4DB863A7C1 \
+	B7574789F5018690043E6DD9C212662E12F3E1DD \
+	B8B301E6105DF628076BD92C5483E55897ABD9B9 \
+	DBCCD103B8B24F86FFAAB025C8BB472CD297D428 \
+	F067B8140F5DD80E1D3B5D92318242FE9A0B1183 \
+	FAA603D58B1BA4EDF65896D0ED340E0E6D545F97
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
-RUN curl -SL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-jaxrs.tar.gz.asc -o tomee.tar.gz.asc
-
-RUN curl -SL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-jaxrs.tar.gz -o tomee.tar.gz \
-	&& tar -zxvf tomee.tar.gz  \
+RUN set -x \
+	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-jaxrs.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-jaxrs.tar.gz -o tomee.tar.gz \
 	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-jaxrs-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-jaxrs-1.7.2 \
 	&& rm bin/*.bat \

--- a/7-jre-1.7.2-plume/Dockerfile
+++ b/7-jre-1.7.2-plume/Dockerfile
@@ -5,14 +5,28 @@ RUN mkdir -p /usr/local/tomee
 
 WORKDIR /usr/local/tomee
 
-RUN curl -SL http://www.apache.org/dist/tomee/KEYS -o KEYS \
-	&& gpg --import KEYS
+# curl -fsSL 'https://www.apache.org/dist/tomee/KEYS' | awk -F ' = ' '$1 ~ /^ +Key fingerprint$/ { gsub(" ", "", $2); print $2 }' | sort -u
+ENV GPG_KEYS \
+	223D3A74B068ECA354DC385CE126833F9CF64915 \
+	7A2744A8A9AAF063C23EB7868EBE7DBE8D050EEF \
+	82D8419BA697F0E7FB85916EE91287822FDB81B1 \
+	9056B710F1E332780DE7AF34CBAEBE39A46C4CA1 \
+	A57DAF81C1B69921F4BA8723A8DE0A4DB863A7C1 \
+	B7574789F5018690043E6DD9C212662E12F3E1DD \
+	B8B301E6105DF628076BD92C5483E55897ABD9B9 \
+	DBCCD103B8B24F86FFAAB025C8BB472CD297D428 \
+	F067B8140F5DD80E1D3B5D92318242FE9A0B1183 \
+	FAA603D58B1BA4EDF65896D0ED340E0E6D545F97
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
-RUN curl -SL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-plume.tar.gz.asc -o tomee.tar.gz.asc
-
-RUN curl -SL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-plume.tar.gz -o tomee.tar.gz \
-	&& tar -zxvf tomee.tar.gz  \
+RUN set -x \
+	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-plume.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-plume.tar.gz -o tomee.tar.gz \
 	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plume-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plume-1.7.2 \
 	&& rm bin/*.bat \

--- a/7-jre-1.7.2-plus/Dockerfile
+++ b/7-jre-1.7.2-plus/Dockerfile
@@ -5,14 +5,28 @@ RUN mkdir -p /usr/local/tomee
 
 WORKDIR /usr/local/tomee
 
-RUN curl -SL http://www.apache.org/dist/tomee/KEYS -o KEYS \
-	&& gpg --import KEYS
+# curl -fsSL 'https://www.apache.org/dist/tomee/KEYS' | awk -F ' = ' '$1 ~ /^ +Key fingerprint$/ { gsub(" ", "", $2); print $2 }' | sort -u
+ENV GPG_KEYS \
+	223D3A74B068ECA354DC385CE126833F9CF64915 \
+	7A2744A8A9AAF063C23EB7868EBE7DBE8D050EEF \
+	82D8419BA697F0E7FB85916EE91287822FDB81B1 \
+	9056B710F1E332780DE7AF34CBAEBE39A46C4CA1 \
+	A57DAF81C1B69921F4BA8723A8DE0A4DB863A7C1 \
+	B7574789F5018690043E6DD9C212662E12F3E1DD \
+	B8B301E6105DF628076BD92C5483E55897ABD9B9 \
+	DBCCD103B8B24F86FFAAB025C8BB472CD297D428 \
+	F067B8140F5DD80E1D3B5D92318242FE9A0B1183 \
+	FAA603D58B1BA4EDF65896D0ED340E0E6D545F97
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
-RUN curl -SL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-plus.tar.gz.asc -o tomee.tar.gz.asc
-
-RUN curl -SL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-plus.tar.gz -o tomee.tar.gz \
-	&& tar -zxvf tomee.tar.gz  \
+RUN set -x \
+	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-plus.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-plus.tar.gz -o tomee.tar.gz \
 	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plus-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plus-1.7.2 \
 	&& rm bin/*.bat \

--- a/7-jre-1.7.2-webprofile/Dockerfile
+++ b/7-jre-1.7.2-webprofile/Dockerfile
@@ -5,14 +5,28 @@ RUN mkdir -p /usr/local/tomee
 
 WORKDIR /usr/local/tomee
 
-RUN curl -SL http://www.apache.org/dist/tomee/KEYS -o KEYS \
-	&& gpg --import KEYS
+# curl -fsSL 'https://www.apache.org/dist/tomee/KEYS' | awk -F ' = ' '$1 ~ /^ +Key fingerprint$/ { gsub(" ", "", $2); print $2 }' | sort -u
+ENV GPG_KEYS \
+	223D3A74B068ECA354DC385CE126833F9CF64915 \
+	7A2744A8A9AAF063C23EB7868EBE7DBE8D050EEF \
+	82D8419BA697F0E7FB85916EE91287822FDB81B1 \
+	9056B710F1E332780DE7AF34CBAEBE39A46C4CA1 \
+	A57DAF81C1B69921F4BA8723A8DE0A4DB863A7C1 \
+	B7574789F5018690043E6DD9C212662E12F3E1DD \
+	B8B301E6105DF628076BD92C5483E55897ABD9B9 \
+	DBCCD103B8B24F86FFAAB025C8BB472CD297D428 \
+	F067B8140F5DD80E1D3B5D92318242FE9A0B1183 \
+	FAA603D58B1BA4EDF65896D0ED340E0E6D545F97
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
-RUN curl -SL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-webprofile.tar.gz.asc -o tomee.tar.gz.asc
-
-RUN curl -SL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-webprofile.tar.gz -o tomee.tar.gz \
-	&& tar -zxvf tomee.tar.gz  \
+RUN set -x \
+	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-webprofile.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-webprofile.tar.gz -o tomee.tar.gz \
 	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-webprofile-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-webprofile-1.7.2 \
 	&& rm bin/*.bat \

--- a/8-jre-1.7.2-jaxrs/Dockerfile
+++ b/8-jre-1.7.2-jaxrs/Dockerfile
@@ -5,14 +5,28 @@ RUN mkdir -p /usr/local/tomee
 
 WORKDIR /usr/local/tomee
 
-RUN curl -SL http://www.apache.org/dist/tomee/KEYS -o KEYS \
-	&& gpg --import KEYS
+# curl -fsSL 'https://www.apache.org/dist/tomee/KEYS' | awk -F ' = ' '$1 ~ /^ +Key fingerprint$/ { gsub(" ", "", $2); print $2 }' | sort -u
+ENV GPG_KEYS \
+	223D3A74B068ECA354DC385CE126833F9CF64915 \
+	7A2744A8A9AAF063C23EB7868EBE7DBE8D050EEF \
+	82D8419BA697F0E7FB85916EE91287822FDB81B1 \
+	9056B710F1E332780DE7AF34CBAEBE39A46C4CA1 \
+	A57DAF81C1B69921F4BA8723A8DE0A4DB863A7C1 \
+	B7574789F5018690043E6DD9C212662E12F3E1DD \
+	B8B301E6105DF628076BD92C5483E55897ABD9B9 \
+	DBCCD103B8B24F86FFAAB025C8BB472CD297D428 \
+	F067B8140F5DD80E1D3B5D92318242FE9A0B1183 \
+	FAA603D58B1BA4EDF65896D0ED340E0E6D545F97
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
-RUN curl -SL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-jaxrs.tar.gz.asc -o tomee.tar.gz.asc
-
-RUN curl -SL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-jaxrs.tar.gz -o tomee.tar.gz \
-	&& tar -zxvf tomee.tar.gz  \
+RUN set -x \
+	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-jaxrs.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-jaxrs.tar.gz -o tomee.tar.gz \
 	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-jaxrs-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-jaxrs-1.7.2 \
 	&& rm bin/*.bat \

--- a/8-jre-1.7.2-plume/Dockerfile
+++ b/8-jre-1.7.2-plume/Dockerfile
@@ -5,14 +5,28 @@ RUN mkdir -p /usr/local/tomee
 
 WORKDIR /usr/local/tomee
 
-RUN curl -SL http://www.apache.org/dist/tomee/KEYS -o KEYS \
-	&& gpg --import KEYS
+# curl -fsSL 'https://www.apache.org/dist/tomee/KEYS' | awk -F ' = ' '$1 ~ /^ +Key fingerprint$/ { gsub(" ", "", $2); print $2 }' | sort -u
+ENV GPG_KEYS \
+	223D3A74B068ECA354DC385CE126833F9CF64915 \
+	7A2744A8A9AAF063C23EB7868EBE7DBE8D050EEF \
+	82D8419BA697F0E7FB85916EE91287822FDB81B1 \
+	9056B710F1E332780DE7AF34CBAEBE39A46C4CA1 \
+	A57DAF81C1B69921F4BA8723A8DE0A4DB863A7C1 \
+	B7574789F5018690043E6DD9C212662E12F3E1DD \
+	B8B301E6105DF628076BD92C5483E55897ABD9B9 \
+	DBCCD103B8B24F86FFAAB025C8BB472CD297D428 \
+	F067B8140F5DD80E1D3B5D92318242FE9A0B1183 \
+	FAA603D58B1BA4EDF65896D0ED340E0E6D545F97
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
-RUN curl -SL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-plume.tar.gz.asc -o tomee.tar.gz.asc
-
-RUN curl -SL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-plume.tar.gz -o tomee.tar.gz \
-	&& tar -zxvf tomee.tar.gz  \
+RUN set -x \
+	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-plume.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-plume.tar.gz -o tomee.tar.gz \
 	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plume-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plume-1.7.2 \
 	&& rm bin/*.bat \

--- a/8-jre-1.7.2-plus/Dockerfile
+++ b/8-jre-1.7.2-plus/Dockerfile
@@ -5,14 +5,28 @@ RUN mkdir -p /usr/local/tomee
 
 WORKDIR /usr/local/tomee
 
-RUN curl -SL http://www.apache.org/dist/tomee/KEYS -o KEYS \
-	&& gpg --import KEYS
+# curl -fsSL 'https://www.apache.org/dist/tomee/KEYS' | awk -F ' = ' '$1 ~ /^ +Key fingerprint$/ { gsub(" ", "", $2); print $2 }' | sort -u
+ENV GPG_KEYS \
+	223D3A74B068ECA354DC385CE126833F9CF64915 \
+	7A2744A8A9AAF063C23EB7868EBE7DBE8D050EEF \
+	82D8419BA697F0E7FB85916EE91287822FDB81B1 \
+	9056B710F1E332780DE7AF34CBAEBE39A46C4CA1 \
+	A57DAF81C1B69921F4BA8723A8DE0A4DB863A7C1 \
+	B7574789F5018690043E6DD9C212662E12F3E1DD \
+	B8B301E6105DF628076BD92C5483E55897ABD9B9 \
+	DBCCD103B8B24F86FFAAB025C8BB472CD297D428 \
+	F067B8140F5DD80E1D3B5D92318242FE9A0B1183 \
+	FAA603D58B1BA4EDF65896D0ED340E0E6D545F97
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
-RUN curl -SL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-plus.tar.gz.asc -o tomee.tar.gz.asc
-
-RUN curl -SL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-plus.tar.gz -o tomee.tar.gz \
-	&& tar -zxvf tomee.tar.gz  \
+RUN set -x \
+	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-plus.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-plus.tar.gz -o tomee.tar.gz \
 	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plus-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plus-1.7.2 \
 	&& rm bin/*.bat \

--- a/8-jre-1.7.2-webprofile/Dockerfile
+++ b/8-jre-1.7.2-webprofile/Dockerfile
@@ -5,14 +5,28 @@ RUN mkdir -p /usr/local/tomee
 
 WORKDIR /usr/local/tomee
 
-RUN curl -SL http://www.apache.org/dist/tomee/KEYS -o KEYS \
-	&& gpg --import KEYS
+# curl -fsSL 'https://www.apache.org/dist/tomee/KEYS' | awk -F ' = ' '$1 ~ /^ +Key fingerprint$/ { gsub(" ", "", $2); print $2 }' | sort -u
+ENV GPG_KEYS \
+	223D3A74B068ECA354DC385CE126833F9CF64915 \
+	7A2744A8A9AAF063C23EB7868EBE7DBE8D050EEF \
+	82D8419BA697F0E7FB85916EE91287822FDB81B1 \
+	9056B710F1E332780DE7AF34CBAEBE39A46C4CA1 \
+	A57DAF81C1B69921F4BA8723A8DE0A4DB863A7C1 \
+	B7574789F5018690043E6DD9C212662E12F3E1DD \
+	B8B301E6105DF628076BD92C5483E55897ABD9B9 \
+	DBCCD103B8B24F86FFAAB025C8BB472CD297D428 \
+	F067B8140F5DD80E1D3B5D92318242FE9A0B1183 \
+	FAA603D58B1BA4EDF65896D0ED340E0E6D545F97
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
-RUN curl -SL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-webprofile.tar.gz.asc -o tomee.tar.gz.asc
-
-RUN curl -SL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-webprofile.tar.gz -o tomee.tar.gz \
-	&& tar -zxvf tomee.tar.gz  \
+RUN set -x \
+	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-webprofile.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-webprofile.tar.gz -o tomee.tar.gz \
 	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-webprofile-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-webprofile-1.7.2 \
 	&& rm bin/*.bat \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,8 +5,22 @@ RUN mkdir -p /usr/local/tomee
 
 WORKDIR /usr/local/tomee
 
-RUN curl -SL http://www.apache.org/dist/tomee/KEYS -o KEYS \
-	&& gpg --import KEYS
+# curl -fsSL 'https://www.apache.org/dist/tomee/KEYS' | awk -F ' = ' '$1 ~ /^ +Key fingerprint$/ { gsub(" ", "", $2); print $2 }' | sort -u
+ENV GPG_KEYS \
+	223D3A74B068ECA354DC385CE126833F9CF64915 \
+	7A2744A8A9AAF063C23EB7868EBE7DBE8D050EEF \
+	82D8419BA697F0E7FB85916EE91287822FDB81B1 \
+	9056B710F1E332780DE7AF34CBAEBE39A46C4CA1 \
+	A57DAF81C1B69921F4BA8723A8DE0A4DB863A7C1 \
+	B7574789F5018690043E6DD9C212662E12F3E1DD \
+	B8B301E6105DF628076BD92C5483E55897ABD9B9 \
+	DBCCD103B8B24F86FFAAB025C8BB472CD297D428 \
+	F067B8140F5DD80E1D3B5D92318242FE9A0B1183 \
+	FAA603D58B1BA4EDF65896D0ED340E0E6D545F97
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
 RUN curl -SL https://dist.apache.org/repos/dist/release/tomee/tomee-%VERSION%/apache-tomee-%VERSION%-%FLAVOR%.tar.gz.asc -o tomee.tar.gz.asc
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -22,11 +22,11 @@ RUN set -xe \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-RUN curl -SL https://dist.apache.org/repos/dist/release/tomee/tomee-%VERSION%/apache-tomee-%VERSION%-%FLAVOR%.tar.gz.asc -o tomee.tar.gz.asc
-
-RUN curl -SL http://apache.rediris.es/tomee/tomee-%VERSION%/apache-tomee-%VERSION%-%FLAVOR%.tar.gz -o tomee.tar.gz \
-	&& tar -zxvf tomee.tar.gz  \
+RUN set -x \
+	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-%VERSION%/apache-tomee-%VERSION%-%FLAVOR%.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL http://apache.rediris.es/tomee/tomee-%VERSION%/apache-tomee-%VERSION%-%FLAVOR%.tar.gz -o tomee.tar.gz \
 	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-%FLAVOR%-%VERSION%/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-%FLAVOR%-%VERSION% \
 	&& rm bin/*.bat \

--- a/create-server.sh
+++ b/create-server.sh
@@ -4,6 +4,8 @@ directory=$1-$2-$3
 
 if [ ! -d "$directory" ]; then
   mkdir -p "$directory"
-  echo "Creating Apache TomEE Dockerfile for $1-$2-$3"
-  sed -e "s;%JAVA%;$1;g" -e "s;%VERSION%;$2;g" -e "s;%FLAVOR%;$3;g" Dockerfile.template > "$directory"/Dockerfile
+  echo "Creating Apache TomEE Dockerfile for $directory"
+else
+  echo "Updating Apache TomEE Dockerfile for $directory"
 fi
+sed -e "s;%JAVA%;$1;g" -e "s;%VERSION%;$2;g" -e "s;%FLAVOR%;$3;g" Dockerfile.template > "$directory"/Dockerfile


### PR DESCRIPTION
I've split this up into several commits to help make it easier to review and talk about each part:

- b54c2ed04c3ff4e3813e1bd88c4105b3e0cdea64: use `--recv-keys` on each key directly instead of trusting the remote `KEYS` file so that each fingerprint is independently verified to be exactly what we expected at `Dockerfile` creation time
- bb2e1336f0564b905a4e48a06257fc10d9a6758b: combine the `.asc` downloading `RUN` into the following `RUN` line which deletes the associated `.asc` file so that it gets removed properly and not just obscured via Docker's layer whiteout, add `-f` to all the `curl` invocations so that `curl` will exit non-zero if there's an issue with the download, and verify the tarball before we extract it
- 5b475887d8f1c926df41740471bc86819d5825a3: adjust `create-server.sh` so that it can also be used to update an existing `Dockerfile` so that changes to `Dockerfile.template` can be more easily distributed to all the individual `Dockerfile`s
- 986e80301ac11cfaa7bf5554ff2516badcda8d96: actually regenerates all the `Dockerfile`s from the template :+1: