### PR TITLE
Fix "gpg" usage to stop relying on deprecated and insecure behavior

### DIFF
--- a/6-jre-1.7.2-jaxrs/Dockerfile
+++ b/6-jre-1.7.2-jaxrs/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-jaxrs.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-jaxrs.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-jaxrs-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-jaxrs-1.7.2 \

--- a/6-jre-1.7.2-plume/Dockerfile
+++ b/6-jre-1.7.2-plume/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-plume.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-plume.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plume-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plume-1.7.2 \

--- a/6-jre-1.7.2-plus/Dockerfile
+++ b/6-jre-1.7.2-plus/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-plus.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-plus.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plus-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plus-1.7.2 \

--- a/6-jre-1.7.2-webprofile/Dockerfile
+++ b/6-jre-1.7.2-webprofile/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-webprofile.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-webprofile.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-webprofile-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-webprofile-1.7.2 \

--- a/6-jre-1.7.3-jaxrs/Dockerfile
+++ b/6-jre-1.7.3-jaxrs/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.3/apache-tomee-1.7.3-jaxrs.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.3/apache-tomee-1.7.3-jaxrs.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-jaxrs-1.7.3/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-jaxrs-1.7.3 \

--- a/6-jre-1.7.3-plume/Dockerfile
+++ b/6-jre-1.7.3-plume/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.3/apache-tomee-1.7.3-plume.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.3/apache-tomee-1.7.3-plume.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plume-1.7.3/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plume-1.7.3 \

--- a/6-jre-1.7.3-plus/Dockerfile
+++ b/6-jre-1.7.3-plus/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.3/apache-tomee-1.7.3-plus.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.3/apache-tomee-1.7.3-plus.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plus-1.7.3/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plus-1.7.3 \

--- a/6-jre-1.7.3-webprofile/Dockerfile
+++ b/6-jre-1.7.3-webprofile/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.3/apache-tomee-1.7.3-webprofile.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.3/apache-tomee-1.7.3-webprofile.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-webprofile-1.7.3/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-webprofile-1.7.3 \

--- a/7-jre-1.7.2-jaxrs/Dockerfile
+++ b/7-jre-1.7.2-jaxrs/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-jaxrs.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-jaxrs.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-jaxrs-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-jaxrs-1.7.2 \

--- a/7-jre-1.7.2-plume/Dockerfile
+++ b/7-jre-1.7.2-plume/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-plume.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-plume.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plume-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plume-1.7.2 \

--- a/7-jre-1.7.2-plus/Dockerfile
+++ b/7-jre-1.7.2-plus/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-plus.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-plus.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plus-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plus-1.7.2 \

--- a/7-jre-1.7.2-webprofile/Dockerfile
+++ b/7-jre-1.7.2-webprofile/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-webprofile.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-webprofile.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-webprofile-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-webprofile-1.7.2 \

--- a/7-jre-1.7.3-jaxrs/Dockerfile
+++ b/7-jre-1.7.3-jaxrs/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.3/apache-tomee-1.7.3-jaxrs.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.3/apache-tomee-1.7.3-jaxrs.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-jaxrs-1.7.3/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-jaxrs-1.7.3 \

--- a/7-jre-1.7.3-plume/Dockerfile
+++ b/7-jre-1.7.3-plume/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.3/apache-tomee-1.7.3-plume.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.3/apache-tomee-1.7.3-plume.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plume-1.7.3/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plume-1.7.3 \

--- a/7-jre-1.7.3-plus/Dockerfile
+++ b/7-jre-1.7.3-plus/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.3/apache-tomee-1.7.3-plus.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.3/apache-tomee-1.7.3-plus.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plus-1.7.3/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plus-1.7.3 \

--- a/7-jre-1.7.3-webprofile/Dockerfile
+++ b/7-jre-1.7.3-webprofile/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.3/apache-tomee-1.7.3-webprofile.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.3/apache-tomee-1.7.3-webprofile.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-webprofile-1.7.3/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-webprofile-1.7.3 \

--- a/7-jre-7.0.0-M1-plume/Dockerfile
+++ b/7-jre-7.0.0-M1-plume/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-7.0.0-M1/apache-tomee-7.0.0-M1-plume.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-7.0.0-M1/apache-tomee-7.0.0-M1-plume.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plume-7.0.0-M1/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plume-7.0.0-M1 \

--- a/7-jre-7.0.0-M1-plus/Dockerfile
+++ b/7-jre-7.0.0-M1-plus/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-7.0.0-M1/apache-tomee-7.0.0-M1-plus.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-7.0.0-M1/apache-tomee-7.0.0-M1-plus.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plus-7.0.0-M1/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plus-7.0.0-M1 \

--- a/7-jre-7.0.0-M1-webprofile/Dockerfile
+++ b/7-jre-7.0.0-M1-webprofile/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-7.0.0-M1/apache-tomee-7.0.0-M1-webprofile.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-7.0.0-M1/apache-tomee-7.0.0-M1-webprofile.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-webprofile-7.0.0-M1/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-webprofile-7.0.0-M1 \

--- a/8-jre-1.7.2-jaxrs/Dockerfile
+++ b/8-jre-1.7.2-jaxrs/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-jaxrs.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-jaxrs.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-jaxrs-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-jaxrs-1.7.2 \

--- a/8-jre-1.7.2-plume/Dockerfile
+++ b/8-jre-1.7.2-plume/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-plume.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-plume.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plume-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plume-1.7.2 \

--- a/8-jre-1.7.2-plus/Dockerfile
+++ b/8-jre-1.7.2-plus/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-plus.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-plus.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plus-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plus-1.7.2 \

--- a/8-jre-1.7.2-webprofile/Dockerfile
+++ b/8-jre-1.7.2-webprofile/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.2/apache-tomee-1.7.2-webprofile.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.2/apache-tomee-1.7.2-webprofile.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-webprofile-1.7.2/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-webprofile-1.7.2 \

--- a/8-jre-1.7.3-jaxrs/Dockerfile
+++ b/8-jre-1.7.3-jaxrs/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.3/apache-tomee-1.7.3-jaxrs.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.3/apache-tomee-1.7.3-jaxrs.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-jaxrs-1.7.3/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-jaxrs-1.7.3 \

--- a/8-jre-1.7.3-plume/Dockerfile
+++ b/8-jre-1.7.3-plume/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.3/apache-tomee-1.7.3-plume.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.3/apache-tomee-1.7.3-plume.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plume-1.7.3/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plume-1.7.3 \

--- a/8-jre-1.7.3-plus/Dockerfile
+++ b/8-jre-1.7.3-plus/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.3/apache-tomee-1.7.3-plus.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.3/apache-tomee-1.7.3-plus.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plus-1.7.3/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plus-1.7.3 \

--- a/8-jre-1.7.3-webprofile/Dockerfile
+++ b/8-jre-1.7.3-webprofile/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-1.7.3/apache-tomee-1.7.3-webprofile.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-1.7.3/apache-tomee-1.7.3-webprofile.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-webprofile-1.7.3/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-webprofile-1.7.3 \

--- a/8-jre-7.0.0-M1-plume/Dockerfile
+++ b/8-jre-7.0.0-M1-plume/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-7.0.0-M1/apache-tomee-7.0.0-M1-plume.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-7.0.0-M1/apache-tomee-7.0.0-M1-plume.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plume-7.0.0-M1/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plume-7.0.0-M1 \

--- a/8-jre-7.0.0-M1-plus/Dockerfile
+++ b/8-jre-7.0.0-M1-plus/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-7.0.0-M1/apache-tomee-7.0.0-M1-plus.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-7.0.0-M1/apache-tomee-7.0.0-M1-plus.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plus-7.0.0-M1/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-plus-7.0.0-M1 \

--- a/8-jre-7.0.0-M1-webprofile/Dockerfile
+++ b/8-jre-7.0.0-M1-webprofile/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-7.0.0-M1/apache-tomee-7.0.0-M1-webprofile.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-7.0.0-M1/apache-tomee-7.0.0-M1-webprofile.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-webprofile-7.0.0-M1/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-webprofile-7.0.0-M1 \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -25,7 +25,7 @@ RUN set -xe \
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-%VERSION%/apache-tomee-%VERSION%-%FLAVOR%.tar.gz.asc -o tomee.tar.gz.asc \
 	&& curl -fSL http://apache.rediris.es/tomee/tomee-%VERSION%/apache-tomee-%VERSION%-%FLAVOR%.tar.gz -o tomee.tar.gz \
-	&& gpg --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-%FLAVOR%-%VERSION%/* /usr/local/tomee \
 	&& rm -Rf apache-tomee-%FLAVOR%-%VERSION% \


### PR DESCRIPTION
See also docker-library/official-images#1420.