### PR TITLE
Altered TomEE source urls to point to Apache's central maven repo

### DIFF
--- a/8-jdk-7.0.1-plume/Dockerfile
+++ b/8-jdk-7.0.1-plume/Dockerfile
@@ -24,8 +24,8 @@ RUN set -xe \
 	done
 
 RUN set -x \
-	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-7.0.1/apache-tomee-7.0.1-plume.tar.gz.asc -o tomee.tar.gz.asc \
-	&& curl -fSL http://apache.rediris.es/tomee/tomee-7.0.1/apache-tomee-7.0.1-plume.tar.gz -o tomee.tar.gz \
+	&& curl -fSL http://repo.maven.apache.org/maven2/org/apache/tomee/apache-tomee/7.0.1/apache-tomee-7.0.1-plume.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL http://repo.maven.apache.org/maven2/org/apache/tomee/apache-tomee/7.0.1/apache-tomee-7.0.1-plume.tar.gz \
 	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plume-7.0.1/* /usr/local/tomee \

--- a/8-jdk-7.0.1-plus/Dockerfile
+++ b/8-jdk-7.0.1-plus/Dockerfile
@@ -24,8 +24,8 @@ RUN set -xe \
 	done
 
 RUN set -x \
-	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-7.0.1/apache-tomee-7.0.1-plus.tar.gz.asc -o tomee.tar.gz.asc \
-	&& curl -fSL http://apache.rediris.es/tomee/tomee-7.0.1/apache-tomee-7.0.1-plus.tar.gz -o tomee.tar.gz \
+	&& curl -fSL http://repo.maven.apache.org/maven2/org/apache/tomee/apache-tomee/7.0.1/apache-tomee-7.0.1-plus.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL http://repo.maven.apache.org/maven2/org/apache/tomee/apache-tomee/7.0.1/apache-tomee-7.0.1-plus.tar.gz -o tomee.tar.gz \
 	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plus-7.0.1/* /usr/local/tomee \

--- a/8-jdk-7.0.1-webprofile/Dockerfile
+++ b/8-jdk-7.0.1-webprofile/Dockerfile
@@ -24,8 +24,8 @@ RUN set -xe \
 	done
 
 RUN set -x \
-	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-7.0.1/apache-tomee-7.0.1-webprofile.tar.gz.asc -o tomee.tar.gz.asc \
-	&& curl -fSL http://apache.rediris.es/tomee/tomee-7.0.1/apache-tomee-7.0.1-webprofile.tar.gz -o tomee.tar.gz \
+	&& curl -fSL http://repo.maven.apache.org/maven2/org/apache/tomee/apache-tomee/7.0.1/apache-tomee-7.0.1-webprofile.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL http://repo.maven.apache.org/maven2/org/apache/tomee/apache-tomee/7.0.1/apache-tomee-7.0.1-webprofile.tar.gz -o tomee.tar.gz \
 	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-webprofile-7.0.1/* /usr/local/tomee \


### PR DESCRIPTION
Updated the curl urls specified in the Dockerfile, matching the URLs used in the TomEE download page. Similar directories and Dockerfiles could be created for the current 7.0.2 release.