### PR TITLE
Convert from "java" (deprecated as of 2016-12-31) to "openjdk"

### DIFF
--- a/6-jre-1.7.2-jaxrs/Dockerfile
+++ b/6-jre-1.7.2-jaxrs/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:6-jre
+FROM openjdk:6-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/6-jre-1.7.2-plume/Dockerfile
+++ b/6-jre-1.7.2-plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:6-jre
+FROM openjdk:6-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/6-jre-1.7.2-plus/Dockerfile
+++ b/6-jre-1.7.2-plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:6-jre
+FROM openjdk:6-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/6-jre-1.7.2-webprofile/Dockerfile
+++ b/6-jre-1.7.2-webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:6-jre
+FROM openjdk:6-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/6-jre-1.7.3-jaxrs/Dockerfile
+++ b/6-jre-1.7.3-jaxrs/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:6-jre
+FROM openjdk:6-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/6-jre-1.7.3-plume/Dockerfile
+++ b/6-jre-1.7.3-plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:6-jre
+FROM openjdk:6-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/6-jre-1.7.3-plus/Dockerfile
+++ b/6-jre-1.7.3-plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:6-jre
+FROM openjdk:6-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/6-jre-1.7.3-webprofile/Dockerfile
+++ b/6-jre-1.7.3-webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:6-jre
+FROM openjdk:6-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/6-jre-1.7.4-jaxrs/Dockerfile
+++ b/6-jre-1.7.4-jaxrs/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:6-jre
+FROM openjdk:6-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/6-jre-1.7.4-plume/Dockerfile
+++ b/6-jre-1.7.4-plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:6-jre
+FROM openjdk:6-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/6-jre-1.7.4-plus/Dockerfile
+++ b/6-jre-1.7.4-plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:6-jre
+FROM openjdk:6-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/6-jre-1.7.4-webprofile/Dockerfile
+++ b/6-jre-1.7.4-webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:6-jre
+FROM openjdk:6-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jdk-7.0.0-plume/Dockerfile
+++ b/7-jdk-7.0.0-plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jdk
+FROM openjdk:7-jdk
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jdk-7.0.0-plus/Dockerfile
+++ b/7-jdk-7.0.0-plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jdk
+FROM openjdk:7-jdk
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jdk-7.0.0-webprofile/Dockerfile
+++ b/7-jdk-7.0.0-webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jdk
+FROM openjdk:7-jdk
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jre-1.7.2-jaxrs/Dockerfile
+++ b/7-jre-1.7.2-jaxrs/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM openjdk:7-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jre-1.7.2-plume/Dockerfile
+++ b/7-jre-1.7.2-plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM openjdk:7-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jre-1.7.2-plus/Dockerfile
+++ b/7-jre-1.7.2-plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM openjdk:7-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jre-1.7.2-webprofile/Dockerfile
+++ b/7-jre-1.7.2-webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM openjdk:7-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jre-1.7.3-jaxrs/Dockerfile
+++ b/7-jre-1.7.3-jaxrs/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM openjdk:7-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jre-1.7.3-plume/Dockerfile
+++ b/7-jre-1.7.3-plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM openjdk:7-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jre-1.7.3-plus/Dockerfile
+++ b/7-jre-1.7.3-plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM openjdk:7-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jre-1.7.3-webprofile/Dockerfile
+++ b/7-jre-1.7.3-webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM openjdk:7-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jre-1.7.4-jaxrs/Dockerfile
+++ b/7-jre-1.7.4-jaxrs/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM openjdk:7-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jre-1.7.4-plume/Dockerfile
+++ b/7-jre-1.7.4-plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM openjdk:7-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jre-1.7.4-plus/Dockerfile
+++ b/7-jre-1.7.4-plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM openjdk:7-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jre-1.7.4-webprofile/Dockerfile
+++ b/7-jre-1.7.4-webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM openjdk:7-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jre-7.0.0-M1-plume/Dockerfile
+++ b/7-jre-7.0.0-M1-plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM openjdk:7-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jre-7.0.0-M1-plus/Dockerfile
+++ b/7-jre-7.0.0-M1-plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM openjdk:7-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jre-7.0.0-M1-webprofile/Dockerfile
+++ b/7-jre-7.0.0-M1-webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM openjdk:7-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jre-7.0.0-M3-plume/Dockerfile
+++ b/7-jre-7.0.0-M3-plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM openjdk:7-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jre-7.0.0-M3-plus/Dockerfile
+++ b/7-jre-7.0.0-M3-plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM openjdk:7-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/7-jre-7.0.0-M3-webprofile/Dockerfile
+++ b/7-jre-7.0.0-M3-webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM openjdk:7-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jdk-7.0.0-plume/Dockerfile
+++ b/8-jdk-7.0.0-plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jdk
+FROM openjdk:8-jdk
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jdk-7.0.0-plus/Dockerfile
+++ b/8-jdk-7.0.0-plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jdk
+FROM openjdk:8-jdk
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jdk-7.0.0-webprofile/Dockerfile
+++ b/8-jdk-7.0.0-webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jdk
+FROM openjdk:8-jdk
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jdk-7.0.1-plume/Dockerfile
+++ b/8-jdk-7.0.1-plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jdk
+FROM openjdk:8-jdk
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jdk-7.0.1-plus/Dockerfile
+++ b/8-jdk-7.0.1-plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jdk
+FROM openjdk:8-jdk
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jdk-7.0.1-webprofile/Dockerfile
+++ b/8-jdk-7.0.1-webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jdk
+FROM openjdk:8-jdk
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-1.7.2-jaxrs/Dockerfile
+++ b/8-jre-1.7.2-jaxrs/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-1.7.2-plume/Dockerfile
+++ b/8-jre-1.7.2-plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-1.7.2-plus/Dockerfile
+++ b/8-jre-1.7.2-plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-1.7.2-webprofile/Dockerfile
+++ b/8-jre-1.7.2-webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-1.7.3-jaxrs/Dockerfile
+++ b/8-jre-1.7.3-jaxrs/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-1.7.3-plume/Dockerfile
+++ b/8-jre-1.7.3-plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-1.7.3-plus/Dockerfile
+++ b/8-jre-1.7.3-plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-1.7.3-webprofile/Dockerfile
+++ b/8-jre-1.7.3-webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-1.7.4-jaxrs/Dockerfile
+++ b/8-jre-1.7.4-jaxrs/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-1.7.4-plume/Dockerfile
+++ b/8-jre-1.7.4-plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-1.7.4-plus/Dockerfile
+++ b/8-jre-1.7.4-plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-1.7.4-webprofile/Dockerfile
+++ b/8-jre-1.7.4-webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-7.0.0-M1-plume/Dockerfile
+++ b/8-jre-7.0.0-M1-plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-7.0.0-M1-plus/Dockerfile
+++ b/8-jre-7.0.0-M1-plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-7.0.0-M1-webprofile/Dockerfile
+++ b/8-jre-7.0.0-M1-webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-7.0.0-M2-plume/Dockerfile
+++ b/8-jre-7.0.0-M2-plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-7.0.0-M2-plus/Dockerfile
+++ b/8-jre-7.0.0-M2-plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-7.0.0-M2-webprofile/Dockerfile
+++ b/8-jre-7.0.0-M2-webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-7.0.0-M3-plume/Dockerfile
+++ b/8-jre-7.0.0-M3-plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-7.0.0-M3-plus/Dockerfile
+++ b/8-jre-7.0.0-M3-plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/8-jre-7.0.0-M3-webprofile/Dockerfile
+++ b/8-jre-7.0.0-M3-webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM java:%JAVA%
+FROM openjdk:%JAVA%
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee


### PR DESCRIPTION
See https://github.com/docker-library/docs/pull/660/files#diff-5b18106a0a6d9cd97a6ecf2793c3347e (https://hub.docker.com/_/java/).