### PR TITLE
TomEE 7.0.3

### DIFF
--- a/8-jre-7.0.3-plume/Dockerfile
+++ b/8-jre-7.0.3-plume/Dockerfile
@@ -26,8 +26,8 @@ RUN set -xe \
 	done
 
 RUN set -x \
-	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-7.0.3/apache-tomee-7.0.3-plume.tar.gz.asc -o tomee.tar.gz.asc \
-	&& curl -fSL http://apache.rediris.es/tomee/tomee-7.0.3/apache-tomee-7.0.3-plume.tar.gz -o tomee.tar.gz \
+	&& curl -fSL https://repo1.maven.org/maven2/org/apache/tomee/apache-tomee/7.0.3/apache-tomee-7.0.3-plume.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL https://repo1.maven.org/maven2/org/apache/tomee/apache-tomee/7.0.3/apache-tomee-7.0.3-plume.tar.gz -o tomee.tar.gz \
 	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plume-7.0.3/* /usr/local/tomee \

--- a/8-jre-7.0.3-plume/Dockerfile
+++ b/8-jre-7.0.3-plume/Dockerfile
@@ -1,0 +1,40 @@
+FROM openjdk:8-jre
+
+ENV PATH /usr/local/tomee/bin:$PATH
+RUN mkdir -p /usr/local/tomee
+
+WORKDIR /usr/local/tomee
+
+# curl 'https://www.apache.org/dist/tomee/KEYS' 2>&1 | grep '^pub' | sed 's#pub.*/\([^ ]*\) .*#\1#'
+ENV GPG_KEYS \
+    9A0B1183 \
+    9CF64915 \
+    D297D428 \
+    8D050EEF \
+    97ABD9B9 \
+    6D545F97 \
+    B863A7C1 \
+    2FDB81B1 \
+    12F3E1DD \
+    5BE6E4C1 \
+    043F71D8 \
+    2678363C
+
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
+
+RUN set -x \
+	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-7.0.3/apache-tomee-7.0.3-plume.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL http://apache.rediris.es/tomee/tomee-7.0.3/apache-tomee-7.0.3-plume.tar.gz -o tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& tar -zxf tomee.tar.gz \
+	&& mv apache-tomee-plume-7.0.3/* /usr/local/tomee \
+	&& rm -Rf apache-tomee-plume-7.0.3 \
+	&& rm bin/*.bat \
+	&& rm tomee.tar.gz*
+
+
+EXPOSE 8080
+CMD ["catalina.sh", "run"]

--- a/8-jre-7.0.3-plus/Dockerfile
+++ b/8-jre-7.0.3-plus/Dockerfile
@@ -26,8 +26,8 @@ RUN set -xe \
 	done
 
 RUN set -x \
-	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-7.0.3/apache-tomee-7.0.3-plus.tar.gz.asc -o tomee.tar.gz.asc \
-	&& curl -fSL http://apache.rediris.es/tomee/tomee-7.0.3/apache-tomee-7.0.3-plus.tar.gz -o tomee.tar.gz \
+	&& curl -fSL https://repo1.maven.org/maven2/org/apache/tomee/apache-tomee/7.0.3/apache-tomee-7.0.3-plus.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL https://repo1.maven.org/maven2/org/apache/tomee/apache-tomee/7.0.3/apache-tomee-7.0.3-plus.tar.gz -o tomee.tar.gz \
     && gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-plus-7.0.3/* /usr/local/tomee \

--- a/8-jre-7.0.3-plus/Dockerfile
+++ b/8-jre-7.0.3-plus/Dockerfile
@@ -1,0 +1,40 @@
+FROM openjdk:8-jre
+
+ENV PATH /usr/local/tomee/bin:$PATH
+RUN mkdir -p /usr/local/tomee
+
+WORKDIR /usr/local/tomee
+
+# curl 'https://www.apache.org/dist/tomee/KEYS' 2>&1 | grep '^pub' | sed 's#pub.*/\([^ ]*\) .*#\1#'
+ENV GPG_KEYS \
+    9A0B1183 \
+    9CF64915 \
+    D297D428 \
+    8D050EEF \
+    97ABD9B9 \
+    6D545F97 \
+    B863A7C1 \
+    2FDB81B1 \
+    12F3E1DD \
+    5BE6E4C1 \
+    043F71D8 \
+    2678363C
+
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
+
+RUN set -x \
+	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-7.0.3/apache-tomee-7.0.3-plus.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL http://apache.rediris.es/tomee/tomee-7.0.3/apache-tomee-7.0.3-plus.tar.gz -o tomee.tar.gz \
+    && gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& tar -zxf tomee.tar.gz \
+	&& mv apache-tomee-plus-7.0.3/* /usr/local/tomee \
+	&& rm -Rf apache-tomee-plus-7.0.3 \
+	&& rm bin/*.bat \
+	&& rm tomee.tar.gz*
+
+
+EXPOSE 8080
+CMD ["catalina.sh", "run"]

--- a/8-jre-7.0.3-webprofile/Dockerfile
+++ b/8-jre-7.0.3-webprofile/Dockerfile
@@ -1,0 +1,40 @@
+FROM openjdk:8-jre
+
+ENV PATH /usr/local/tomee/bin:$PATH
+RUN mkdir -p /usr/local/tomee
+
+WORKDIR /usr/local/tomee
+
+# curl 'https://www.apache.org/dist/tomee/KEYS' 2>&1 | grep '^pub' | sed 's#pub.*/\([^ ]*\) .*#\1#'
+ENV GPG_KEYS \
+    9A0B1183 \
+    9CF64915 \
+    D297D428 \
+    8D050EEF \
+    97ABD9B9 \
+    6D545F97 \
+    B863A7C1 \
+    2FDB81B1 \
+    12F3E1DD \
+    5BE6E4C1 \
+    043F71D8 \
+    2678363C
+
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
+
+RUN set -x \
+	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-7.0.3/apache-tomee-7.0.3-webprofile.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL http://apache.rediris.es/tomee/tomee-7.0.3/apache-tomee-7.0.3-webprofile.tar.gz -o tomee.tar.gz \
+	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
+	&& tar -zxf tomee.tar.gz \
+	&& mv apache-tomee-webprofile-7.0.3/* /usr/local/tomee \
+	&& rm -Rf apache-tomee-webprofile-7.0.3 \
+	&& rm bin/*.bat \
+	&& rm tomee.tar.gz*
+
+
+EXPOSE 8080
+CMD ["catalina.sh", "run"]

--- a/8-jre-7.0.3-webprofile/Dockerfile
+++ b/8-jre-7.0.3-webprofile/Dockerfile
@@ -26,8 +26,8 @@ RUN set -xe \
 	done
 
 RUN set -x \
-	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-7.0.3/apache-tomee-7.0.3-webprofile.tar.gz.asc -o tomee.tar.gz.asc \
-	&& curl -fSL http://apache.rediris.es/tomee/tomee-7.0.3/apache-tomee-7.0.3-webprofile.tar.gz -o tomee.tar.gz \
+	&& curl -fSL https://repo1.maven.org/maven2/org/apache/tomee/apache-tomee/7.0.3/apache-tomee-7.0.3-webprofile.tar.gz.asc -o tomee.tar.gz.asc \
+	&& curl -fSL https://repo1.maven.org/maven2/org/apache/tomee/apache-tomee/7.0.3/apache-tomee-7.0.3-webprofile.tar.gz -o tomee.tar.gz \
 	&& gpg --batch --verify tomee.tar.gz.asc tomee.tar.gz \
 	&& tar -zxf tomee.tar.gz \
 	&& mv apache-tomee-webprofile-7.0.3/* /usr/local/tomee \


### PR DESCRIPTION
Added Dockerfile for tomee 7.0.3 webprofile, plus and plume.

I changed `GPG_KEYS` env var to use `pub` key ids instead of key `fingerprint` because not all keys have a fingerprint, like R. Manibucau's key:

```
pub   2048D/2678363C 2016-09-22
uid                  Romain Manni-Bucau <rmannibucau@apache.org>
sub   2048g/25FC7483 2016-09-22
```

Commented command to retrieve them is also updated, thanks to @rmannibucau
