### PR TITLE
Corrected EXPOSE

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -38,7 +38,7 @@ RUN set -x \
 
 
 EXPOSE 8080/tcp
-EXPOSÉ 8443/tcp
+EXPOSE 8443/tcp
 
 VOLUME [/usr/local/tomee/logs] 
 VOLUME [/usr/local/tomee/conf] 


### PR DESCRIPTION
Unfortunatly in my check-in, there was a syntax error the 2nd EXPOSE was written as EXPOSÉ. I corrected this, sorry for that. 