### PR TITLE
move the new ENVs lower for effecient building

### DIFF
--- a/TomEE-7.0/jre8/microprofile/Dockerfile
+++ b/TomEE-7.0/jre8/microprofile/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:8-jre
 
-ENV TOMEE_VER 7.0.6
-ENV TOMEE_BUILD microprofile
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee
 
@@ -28,6 +26,9 @@ RUN set -xe \
         gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
     done
+
+ENV TOMEE_VER 7.0.6
+ENV TOMEE_BUILD microprofile
 
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.asc -o tomee.tar.gz.asc \

--- a/TomEE-7.0/jre8/plume/Dockerfile
+++ b/TomEE-7.0/jre8/plume/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:8-jre
 
-ENV TOMEE_VER 7.0.6
-ENV TOMEE_BUILD plume
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee
 
@@ -28,6 +26,9 @@ RUN set -xe \
         gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
     done
+
+ENV TOMEE_VER 7.0.6
+ENV TOMEE_BUILD plume
 
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.asc -o tomee.tar.gz.asc \

--- a/TomEE-7.0/jre8/plus/Dockerfile
+++ b/TomEE-7.0/jre8/plus/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:8-jre
 
-ENV TOMEE_VER 7.0.6
-ENV TOMEE_BUILD plus
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee
 
@@ -28,6 +26,9 @@ RUN set -xe \
         gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
     done
+
+ENV TOMEE_VER 7.0.6
+ENV TOMEE_BUILD plus
 
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.asc -o tomee.tar.gz.asc \

--- a/TomEE-7.0/jre8/webprofile/Dockerfile
+++ b/TomEE-7.0/jre8/webprofile/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:8-jre
 
-ENV TOMEE_VER 7.0.6
-ENV TOMEE_BUILD webprofile
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee
 
@@ -28,6 +26,9 @@ RUN set -xe \
         gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
     done
+
+ENV TOMEE_VER 7.0.6
+ENV TOMEE_BUILD webprofile
 
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.asc -o tomee.tar.gz.asc \

--- a/TomEE-7.1/jre8/microprofile/Dockerfile
+++ b/TomEE-7.1/jre8/microprofile/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:8-jre
 
-ENV TOMEE_VER 7.1.1
-ENV TOMEE_BUILD microprofile
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee
 
@@ -28,6 +26,9 @@ RUN set -xe \
         gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
     done
+
+ENV TOMEE_VER 7.1.1
+ENV TOMEE_BUILD microprofile
 
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.asc -o tomee.tar.gz.asc \

--- a/TomEE-7.1/jre8/plume/Dockerfile
+++ b/TomEE-7.1/jre8/plume/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:8-jre
 
-ENV TOMEE_VER 7.1.1
-ENV TOMEE_BUILD plume
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee
 
@@ -28,6 +26,9 @@ RUN set -xe \
         gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
     done
+
+ENV TOMEE_VER 7.1.1
+ENV TOMEE_BUILD plume
 
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.asc -o tomee.tar.gz.asc \

--- a/TomEE-7.1/jre8/plus/Dockerfile
+++ b/TomEE-7.1/jre8/plus/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:8-jre
 
-ENV TOMEE_VER 7.1.1
-ENV TOMEE_BUILD plus
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee
 
@@ -28,6 +26,9 @@ RUN set -xe \
         gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
     done
+
+ENV TOMEE_VER 7.1.1
+ENV TOMEE_BUILD plus
 
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.asc -o tomee.tar.gz.asc \

--- a/TomEE-7.1/jre8/webprofile/Dockerfile
+++ b/TomEE-7.1/jre8/webprofile/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:8-jre
 
-ENV TOMEE_VER 7.1.1
-ENV TOMEE_BUILD webprofile
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee
 
@@ -28,6 +26,9 @@ RUN set -xe \
         gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
     done
+
+ENV TOMEE_VER 7.1.1
+ENV TOMEE_BUILD webprofile
 
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.asc -o tomee.tar.gz.asc \

--- a/TomEE-8.0/jre11/microprofile/Dockerfile
+++ b/TomEE-8.0/jre11/microprofile/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:11-jre
 
-ENV TOMEE_VER 8.0.0
-ENV TOMEE_BUILD microprofile
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee
 
@@ -28,6 +26,9 @@ RUN set -xe \
         gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
     done
+
+ENV TOMEE_VER 8.0.0
+ENV TOMEE_BUILD microprofile
 
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.asc -o tomee.tar.gz.asc \

--- a/TomEE-8.0/jre11/plume/Dockerfile
+++ b/TomEE-8.0/jre11/plume/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:11-jre
 
-ENV TOMEE_VER 8.0.0
-ENV TOMEE_BUILD plume
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee
 
@@ -28,6 +26,9 @@ RUN set -xe \
         gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
     done
+
+ENV TOMEE_VER 8.0.0
+ENV TOMEE_BUILD plume
 
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.asc -o tomee.tar.gz.asc \

--- a/TomEE-8.0/jre11/plus/Dockerfile
+++ b/TomEE-8.0/jre11/plus/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:11-jre
 
-ENV TOMEE_VER 8.0.0
-ENV TOMEE_BUILD plus
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee
 
@@ -28,6 +26,9 @@ RUN set -xe \
         gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
     done
+
+ENV TOMEE_VER 8.0.0
+ENV TOMEE_BUILD plus
 
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.asc -o tomee.tar.gz.asc \

--- a/TomEE-8.0/jre11/webprofile/Dockerfile
+++ b/TomEE-8.0/jre11/webprofile/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:11-jre
 
-ENV TOMEE_VER 8.0.0
-ENV TOMEE_BUILD webprofile
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee
 
@@ -28,6 +26,9 @@ RUN set -xe \
         gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
     done
+
+ENV TOMEE_VER 8.0.0
+ENV TOMEE_BUILD webprofile
 
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.asc -o tomee.tar.gz.asc \

--- a/TomEE-8.0/jre8/microprofile/Dockerfile
+++ b/TomEE-8.0/jre8/microprofile/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:8-jre
 
-ENV TOMEE_VER 8.0.0
-ENV TOMEE_BUILD microprofile
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee
 
@@ -28,6 +26,9 @@ RUN set -xe \
         gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
     done
+
+ENV TOMEE_VER 8.0.0
+ENV TOMEE_BUILD microprofile
 
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.asc -o tomee.tar.gz.asc \

--- a/TomEE-8.0/jre8/plume/Dockerfile
+++ b/TomEE-8.0/jre8/plume/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:8-jre
 
-ENV TOMEE_VER 8.0.0
-ENV TOMEE_BUILD plume
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee
 
@@ -28,6 +26,9 @@ RUN set -xe \
         gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
     done
+
+ENV TOMEE_VER 8.0.0
+ENV TOMEE_BUILD plume
 
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.asc -o tomee.tar.gz.asc \

--- a/TomEE-8.0/jre8/plus/Dockerfile
+++ b/TomEE-8.0/jre8/plus/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:8-jre
 
-ENV TOMEE_VER 8.0.0
-ENV TOMEE_BUILD plus
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee
 
@@ -28,6 +26,9 @@ RUN set -xe \
         gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
     done
+
+ENV TOMEE_VER 8.0.0
+ENV TOMEE_BUILD plus
 
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.asc -o tomee.tar.gz.asc \

--- a/TomEE-8.0/jre8/webprofile/Dockerfile
+++ b/TomEE-8.0/jre8/webprofile/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:8-jre
 
-ENV TOMEE_VER 8.0.0
-ENV TOMEE_BUILD webprofile
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee
 
@@ -28,6 +26,9 @@ RUN set -xe \
         gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
     done
+
+ENV TOMEE_VER 8.0.0
+ENV TOMEE_BUILD webprofile
 
 RUN set -x \
 	&& curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.asc -o tomee.tar.gz.asc \


### PR DESCRIPTION
Docker Official asked me to move the new ENVs lower to maximize the build cache.