### PR TITLE
TomEE version bump to 8.0.13 and 9.0.0.RC1

### DIFF
--- a/TomEE-8.0/jre11/OpenJDK/debian/microprofile/Dockerfile
+++ b/TomEE-8.0/jre11/OpenJDK/debian/microprofile/Dockerfile
@@ -48,7 +48,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre11/OpenJDK/debian/plume/Dockerfile
+++ b/TomEE-8.0/jre11/OpenJDK/debian/plume/Dockerfile
@@ -48,7 +48,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD plume
 
 RUN set -x \

--- a/TomEE-8.0/jre11/OpenJDK/debian/plus/Dockerfile
+++ b/TomEE-8.0/jre11/OpenJDK/debian/plus/Dockerfile
@@ -48,7 +48,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD plus
 
 RUN set -x \

--- a/TomEE-8.0/jre11/OpenJDK/debian/webprofile/Dockerfile
+++ b/TomEE-8.0/jre11/OpenJDK/debian/webprofile/Dockerfile
@@ -48,7 +48,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre11/Semeru/ubuntu/microprofile/Dockerfile
+++ b/TomEE-8.0/jre11/Semeru/ubuntu/microprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre11/Semeru/ubuntu/plume/Dockerfile
+++ b/TomEE-8.0/jre11/Semeru/ubuntu/plume/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD plume
 
 RUN set -x \

--- a/TomEE-8.0/jre11/Semeru/ubuntu/plus/Dockerfile
+++ b/TomEE-8.0/jre11/Semeru/ubuntu/plus/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD plus
 
 RUN set -x \

--- a/TomEE-8.0/jre11/Semeru/ubuntu/webprofile/Dockerfile
+++ b/TomEE-8.0/jre11/Semeru/ubuntu/webprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre11/Temurin/alpine/microprofile/Dockerfile
+++ b/TomEE-8.0/jre11/Temurin/alpine/microprofile/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \
@@ -59,7 +59,7 @@ RUN set -x \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512 \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
-  && sha512sum -c tomee.tar.gz.sha512 \
+  && sed "s/\t/  /" tomee.tar.gz.sha512 | sha512sum -c - \
   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee \
   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \

--- a/TomEE-8.0/jre11/Temurin/alpine/plume/Dockerfile
+++ b/TomEE-8.0/jre11/Temurin/alpine/plume/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD plume
 
 RUN set -x \
@@ -59,7 +59,7 @@ RUN set -x \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512 \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
-  && sha512sum -c tomee.tar.gz.sha512 \
+  && sed "s/\t/  /" tomee.tar.gz.sha512 | sha512sum -c - \
   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee \
   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \

--- a/TomEE-8.0/jre11/Temurin/alpine/plus/Dockerfile
+++ b/TomEE-8.0/jre11/Temurin/alpine/plus/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD plus
 
 RUN set -x \
@@ -59,7 +59,7 @@ RUN set -x \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512 \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
-  && sha512sum -c tomee.tar.gz.sha512 \
+  && sed "s/\t/  /" tomee.tar.gz.sha512 | sha512sum -c - \
   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee \
   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \

--- a/TomEE-8.0/jre11/Temurin/alpine/webprofile/Dockerfile
+++ b/TomEE-8.0/jre11/Temurin/alpine/webprofile/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \
@@ -59,7 +59,7 @@ RUN set -x \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512 \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
-  && sha512sum -c tomee.tar.gz.sha512 \
+  && sed "s/\t/  /" tomee.tar.gz.sha512 | sha512sum -c - \
   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee \
   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \

--- a/TomEE-8.0/jre11/Temurin/ubuntu/microprofile/Dockerfile
+++ b/TomEE-8.0/jre11/Temurin/ubuntu/microprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre11/Temurin/ubuntu/plume/Dockerfile
+++ b/TomEE-8.0/jre11/Temurin/ubuntu/plume/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD plume
 
 RUN set -x \

--- a/TomEE-8.0/jre11/Temurin/ubuntu/plus/Dockerfile
+++ b/TomEE-8.0/jre11/Temurin/ubuntu/plus/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD plus
 
 RUN set -x \

--- a/TomEE-8.0/jre11/Temurin/ubuntu/webprofile/Dockerfile
+++ b/TomEE-8.0/jre11/Temurin/ubuntu/webprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre17/Semeru/ubuntu/microprofile/Dockerfile
+++ b/TomEE-8.0/jre17/Semeru/ubuntu/microprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre17/Semeru/ubuntu/plume/Dockerfile
+++ b/TomEE-8.0/jre17/Semeru/ubuntu/plume/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD plume
 
 RUN set -x \

--- a/TomEE-8.0/jre17/Semeru/ubuntu/plus/Dockerfile
+++ b/TomEE-8.0/jre17/Semeru/ubuntu/plus/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD plus
 
 RUN set -x \

--- a/TomEE-8.0/jre17/Semeru/ubuntu/webprofile/Dockerfile
+++ b/TomEE-8.0/jre17/Semeru/ubuntu/webprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre17/Temurin/alpine/microprofile/Dockerfile
+++ b/TomEE-8.0/jre17/Temurin/alpine/microprofile/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \
@@ -59,7 +59,7 @@ RUN set -x \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512 \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
-  && sha512sum -c tomee.tar.gz.sha512 \
+  && sed "s/\t/  /" tomee.tar.gz.sha512 | sha512sum -c - \
   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee \
   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \

--- a/TomEE-8.0/jre17/Temurin/alpine/plume/Dockerfile
+++ b/TomEE-8.0/jre17/Temurin/alpine/plume/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD plume
 
 RUN set -x \
@@ -59,7 +59,7 @@ RUN set -x \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512 \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
-  && sha512sum -c tomee.tar.gz.sha512 \
+  && sed "s/\t/  /" tomee.tar.gz.sha512 | sha512sum -c - \
   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee \
   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \

--- a/TomEE-8.0/jre17/Temurin/alpine/plus/Dockerfile
+++ b/TomEE-8.0/jre17/Temurin/alpine/plus/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD plus
 
 RUN set -x \
@@ -59,7 +59,7 @@ RUN set -x \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512 \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
-  && sha512sum -c tomee.tar.gz.sha512 \
+  && sed "s/\t/  /" tomee.tar.gz.sha512 | sha512sum -c - \
   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee \
   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \

--- a/TomEE-8.0/jre17/Temurin/alpine/webprofile/Dockerfile
+++ b/TomEE-8.0/jre17/Temurin/alpine/webprofile/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \
@@ -59,7 +59,7 @@ RUN set -x \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512 \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
-  && sha512sum -c tomee.tar.gz.sha512 \
+  && sed "s/\t/  /" tomee.tar.gz.sha512 | sha512sum -c - \
   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee \
   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \

--- a/TomEE-8.0/jre17/Temurin/ubuntu/microprofile/Dockerfile
+++ b/TomEE-8.0/jre17/Temurin/ubuntu/microprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre17/Temurin/ubuntu/plume/Dockerfile
+++ b/TomEE-8.0/jre17/Temurin/ubuntu/plume/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD plume
 
 RUN set -x \

--- a/TomEE-8.0/jre17/Temurin/ubuntu/plus/Dockerfile
+++ b/TomEE-8.0/jre17/Temurin/ubuntu/plus/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD plus
 
 RUN set -x \

--- a/TomEE-8.0/jre17/Temurin/ubuntu/webprofile/Dockerfile
+++ b/TomEE-8.0/jre17/Temurin/ubuntu/webprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre8/OpenJDK/debian/microprofile/Dockerfile
+++ b/TomEE-8.0/jre8/OpenJDK/debian/microprofile/Dockerfile
@@ -48,7 +48,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre8/OpenJDK/debian/plume/Dockerfile
+++ b/TomEE-8.0/jre8/OpenJDK/debian/plume/Dockerfile
@@ -48,7 +48,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD plume
 
 RUN set -x \

--- a/TomEE-8.0/jre8/OpenJDK/debian/plus/Dockerfile
+++ b/TomEE-8.0/jre8/OpenJDK/debian/plus/Dockerfile
@@ -48,7 +48,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD plus
 
 RUN set -x \

--- a/TomEE-8.0/jre8/OpenJDK/debian/webprofile/Dockerfile
+++ b/TomEE-8.0/jre8/OpenJDK/debian/webprofile/Dockerfile
@@ -48,7 +48,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre8/Temurin/alpine/microprofile/Dockerfile
+++ b/TomEE-8.0/jre8/Temurin/alpine/microprofile/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \
@@ -59,7 +59,7 @@ RUN set -x \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512 \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
-  && sha512sum -c tomee.tar.gz.sha512 \
+  && sed "s/\t/  /" tomee.tar.gz.sha512 | sha512sum -c - \
   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee \
   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \

--- a/TomEE-8.0/jre8/Temurin/alpine/plume/Dockerfile
+++ b/TomEE-8.0/jre8/Temurin/alpine/plume/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD plume
 
 RUN set -x \
@@ -59,7 +59,7 @@ RUN set -x \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512 \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
-  && sha512sum -c tomee.tar.gz.sha512 \
+  && sed "s/\t/  /" tomee.tar.gz.sha512 | sha512sum -c - \
   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee \
   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \

--- a/TomEE-8.0/jre8/Temurin/alpine/plus/Dockerfile
+++ b/TomEE-8.0/jre8/Temurin/alpine/plus/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD plus
 
 RUN set -x \
@@ -59,7 +59,7 @@ RUN set -x \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512 \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
-  && sha512sum -c tomee.tar.gz.sha512 \
+  && sed "s/\t/  /" tomee.tar.gz.sha512 | sha512sum -c - \
   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee \
   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \

--- a/TomEE-8.0/jre8/Temurin/alpine/webprofile/Dockerfile
+++ b/TomEE-8.0/jre8/Temurin/alpine/webprofile/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \
@@ -59,7 +59,7 @@ RUN set -x \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512 \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
-  && sha512sum -c tomee.tar.gz.sha512 \
+  && sed "s/\t/  /" tomee.tar.gz.sha512 | sha512sum -c - \
   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee \
   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \

--- a/TomEE-8.0/jre8/Temurin/ubuntu/microprofile/Dockerfile
+++ b/TomEE-8.0/jre8/Temurin/ubuntu/microprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre8/Temurin/ubuntu/plume/Dockerfile
+++ b/TomEE-8.0/jre8/Temurin/ubuntu/plume/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD plume
 
 RUN set -x \

--- a/TomEE-8.0/jre8/Temurin/ubuntu/plus/Dockerfile
+++ b/TomEE-8.0/jre8/Temurin/ubuntu/plus/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD plus
 
 RUN set -x \

--- a/TomEE-8.0/jre8/Temurin/ubuntu/webprofile/Dockerfile
+++ b/TomEE-8.0/jre8/Temurin/ubuntu/webprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.12
+ENV TOMEE_VER 8.0.13
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \

--- a/TomEE-9.0/jre11/Semeru/ubuntu/microprofile/Dockerfile
+++ b/TomEE-9.0/jre11/Semeru/ubuntu/microprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \

--- a/TomEE-9.0/jre11/Semeru/ubuntu/plume/Dockerfile
+++ b/TomEE-9.0/jre11/Semeru/ubuntu/plume/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD plume
 
 RUN set -x \

--- a/TomEE-9.0/jre11/Semeru/ubuntu/plus/Dockerfile
+++ b/TomEE-9.0/jre11/Semeru/ubuntu/plus/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD plus
 
 RUN set -x \

--- a/TomEE-9.0/jre11/Semeru/ubuntu/webprofile/Dockerfile
+++ b/TomEE-9.0/jre11/Semeru/ubuntu/webprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \

--- a/TomEE-9.0/jre11/Temurin/alpine/microprofile/Dockerfile
+++ b/TomEE-9.0/jre11/Temurin/alpine/microprofile/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \
@@ -59,8 +59,7 @@ RUN set -x \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512 \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
-  #&& echo `cat tomee.tar.gz.sha512` | sha512sum -c - \
-  && sha512sum -c tomee.tar.gz.sha512 \
+  && sed "s/\t/  /" tomee.tar.gz.sha512 | sha512sum -c - \
   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee \
   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \

--- a/TomEE-9.0/jre11/Temurin/alpine/plume/Dockerfile
+++ b/TomEE-9.0/jre11/Temurin/alpine/plume/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD plume
 
 RUN set -x \
@@ -59,8 +59,7 @@ RUN set -x \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512 \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
-  #&& echo `cat tomee.tar.gz.sha512` | sha512sum -c - \
-  && sha512sum -c tomee.tar.gz.sha512 \
+  && sed "s/\t/  /" tomee.tar.gz.sha512 | sha512sum -c - \
   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee \
   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \

--- a/TomEE-9.0/jre11/Temurin/alpine/plus/Dockerfile
+++ b/TomEE-9.0/jre11/Temurin/alpine/plus/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD plus
 
 RUN set -x \
@@ -59,8 +59,7 @@ RUN set -x \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512 \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
-  #&& echo `cat tomee.tar.gz.sha512` | sha512sum -c - \
-  && sha512sum -c tomee.tar.gz.sha512 \
+  && sed "s/\t/  /" tomee.tar.gz.sha512 | sha512sum -c - \
   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee \
   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \

--- a/TomEE-9.0/jre11/Temurin/alpine/webprofile/Dockerfile
+++ b/TomEE-9.0/jre11/Temurin/alpine/webprofile/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \
@@ -59,8 +59,7 @@ RUN set -x \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512 \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
-  #&& echo `cat tomee.tar.gz.sha512` | sha512sum -c - \
-  && sha512sum -c tomee.tar.gz.sha512 \
+  && sed "s/\t/  /" tomee.tar.gz.sha512 | sha512sum -c - \
   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee \
   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \

--- a/TomEE-9.0/jre11/Temurin/ubuntu/microprofile/Dockerfile
+++ b/TomEE-9.0/jre11/Temurin/ubuntu/microprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \

--- a/TomEE-9.0/jre11/Temurin/ubuntu/plume/Dockerfile
+++ b/TomEE-9.0/jre11/Temurin/ubuntu/plume/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD plume
 
 RUN set -x \

--- a/TomEE-9.0/jre11/Temurin/ubuntu/plus/Dockerfile
+++ b/TomEE-9.0/jre11/Temurin/ubuntu/plus/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD plus
 
 RUN set -x \

--- a/TomEE-9.0/jre11/Temurin/ubuntu/webprofile/Dockerfile
+++ b/TomEE-9.0/jre11/Temurin/ubuntu/webprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \

--- a/TomEE-9.0/jre17/Semeru/ubuntu/microprofile/Dockerfile
+++ b/TomEE-9.0/jre17/Semeru/ubuntu/microprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \

--- a/TomEE-9.0/jre17/Semeru/ubuntu/plume/Dockerfile
+++ b/TomEE-9.0/jre17/Semeru/ubuntu/plume/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD plume
 
 RUN set -x \

--- a/TomEE-9.0/jre17/Semeru/ubuntu/plus/Dockerfile
+++ b/TomEE-9.0/jre17/Semeru/ubuntu/plus/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD plus
 
 RUN set -x \

--- a/TomEE-9.0/jre17/Semeru/ubuntu/webprofile/Dockerfile
+++ b/TomEE-9.0/jre17/Semeru/ubuntu/webprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \

--- a/TomEE-9.0/jre17/Temurin/alpine/microprofile/Dockerfile
+++ b/TomEE-9.0/jre17/Temurin/alpine/microprofile/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \
@@ -59,8 +59,7 @@ RUN set -x \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512 \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
-  #&& echo `cat tomee.tar.gz.sha512` | sha512sum -c - \
-  && sha512sum -c tomee.tar.gz.sha512 \
+  && sed "s/\t/  /" tomee.tar.gz.sha512 | sha512sum -c - \
   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee \
   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \

--- a/TomEE-9.0/jre17/Temurin/alpine/plume/Dockerfile
+++ b/TomEE-9.0/jre17/Temurin/alpine/plume/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD plume
 
 RUN set -x \
@@ -59,8 +59,7 @@ RUN set -x \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512 \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
-  #&& echo `cat tomee.tar.gz.sha512` | sha512sum -c - \
-  && sha512sum -c tomee.tar.gz.sha512 \
+  && sed "s/\t/  /" tomee.tar.gz.sha512 | sha512sum -c - \
   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee \
   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \

--- a/TomEE-9.0/jre17/Temurin/alpine/plus/Dockerfile
+++ b/TomEE-9.0/jre17/Temurin/alpine/plus/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD plus
 
 RUN set -x \
@@ -59,8 +59,7 @@ RUN set -x \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512 \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
-  #&& echo `cat tomee.tar.gz.sha512` | sha512sum -c - \
-  && sha512sum -c tomee.tar.gz.sha512 \
+  && sed "s/\t/  /" tomee.tar.gz.sha512 | sha512sum -c - \
   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee \
   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \

--- a/TomEE-9.0/jre17/Temurin/alpine/webprofile/Dockerfile
+++ b/TomEE-9.0/jre17/Temurin/alpine/webprofile/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \
@@ -59,8 +59,7 @@ RUN set -x \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512 \
   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
-  #&& echo `cat tomee.tar.gz.sha512` | sha512sum -c - \
-  && sha512sum -c tomee.tar.gz.sha512 \
+  && sed "s/\t/  /" tomee.tar.gz.sha512 | sha512sum -c - \
   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \
   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee \
   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz \

--- a/TomEE-9.0/jre17/Temurin/ubuntu/microprofile/Dockerfile
+++ b/TomEE-9.0/jre17/Temurin/ubuntu/microprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \

--- a/TomEE-9.0/jre17/Temurin/ubuntu/plume/Dockerfile
+++ b/TomEE-9.0/jre17/Temurin/ubuntu/plume/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD plume
 
 RUN set -x \

--- a/TomEE-9.0/jre17/Temurin/ubuntu/plus/Dockerfile
+++ b/TomEE-9.0/jre17/Temurin/ubuntu/plus/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD plus
 
 RUN set -x \

--- a/TomEE-9.0/jre17/Temurin/ubuntu/webprofile/Dockerfile
+++ b/TomEE-9.0/jre17/Temurin/ubuntu/webprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 9.0.0-M8
+ENV TOMEE_VER 9.0.0.RC1
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \


### PR DESCRIPTION
Straightforward update of both TomEE 8.0 and 9.0 releases.

For the Alpine image we introduce an inline replacement of tabs with spaces to work around the checksum issue, as _sha512sum_ expects exactly two spaces between checksum and filename. Ubuntu/Debian implementations tolerate both, so no change required here..
