### PR TITLE
Switch to Ubuntu Jammy base images for TomEE 9

### DIFF
--- a/TomEE-9.0/jre11/Semeru/ubuntu/microprofile/Dockerfile
+++ b/TomEE-9.0/jre11/Semeru/ubuntu/microprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-11-jre-focal
+FROM ibm-semeru-runtimes:open-11-jre-jammy
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/TomEE-9.0/jre11/Semeru/ubuntu/plume/Dockerfile
+++ b/TomEE-9.0/jre11/Semeru/ubuntu/plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-11-jre-focal
+FROM ibm-semeru-runtimes:open-11-jre-jammy
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/TomEE-9.0/jre11/Semeru/ubuntu/plus/Dockerfile
+++ b/TomEE-9.0/jre11/Semeru/ubuntu/plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-11-jre-focal
+FROM ibm-semeru-runtimes:open-11-jre-jammy
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/TomEE-9.0/jre11/Semeru/ubuntu/webprofile/Dockerfile
+++ b/TomEE-9.0/jre11/Semeru/ubuntu/webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-11-jre-focal
+FROM ibm-semeru-runtimes:open-11-jre-jammy
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/TomEE-9.0/jre11/Temurin/ubuntu/microprofile/Dockerfile
+++ b/TomEE-9.0/jre11/Temurin/ubuntu/microprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre-focal
+FROM eclipse-temurin:11-jre-jammy
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/TomEE-9.0/jre11/Temurin/ubuntu/plume/Dockerfile
+++ b/TomEE-9.0/jre11/Temurin/ubuntu/plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre-focal
+FROM eclipse-temurin:11-jre-jammy
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/TomEE-9.0/jre11/Temurin/ubuntu/plus/Dockerfile
+++ b/TomEE-9.0/jre11/Temurin/ubuntu/plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre-focal
+FROM eclipse-temurin:11-jre-jammy
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/TomEE-9.0/jre11/Temurin/ubuntu/webprofile/Dockerfile
+++ b/TomEE-9.0/jre11/Temurin/ubuntu/webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre-focal
+FROM eclipse-temurin:11-jre-jammy
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/TomEE-9.0/jre17/Semeru/ubuntu/microprofile/Dockerfile
+++ b/TomEE-9.0/jre17/Semeru/ubuntu/microprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-17-jre-focal
+FROM ibm-semeru-runtimes:open-17-jre-jammy
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/TomEE-9.0/jre17/Semeru/ubuntu/plume/Dockerfile
+++ b/TomEE-9.0/jre17/Semeru/ubuntu/plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-17-jre-focal
+FROM ibm-semeru-runtimes:open-17-jre-jammy
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/TomEE-9.0/jre17/Semeru/ubuntu/plus/Dockerfile
+++ b/TomEE-9.0/jre17/Semeru/ubuntu/plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-17-jre-focal
+FROM ibm-semeru-runtimes:open-17-jre-jammy
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/TomEE-9.0/jre17/Semeru/ubuntu/webprofile/Dockerfile
+++ b/TomEE-9.0/jre17/Semeru/ubuntu/webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM ibm-semeru-runtimes:open-17-jre-focal
+FROM ibm-semeru-runtimes:open-17-jre-jammy
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/TomEE-9.0/jre17/Temurin/ubuntu/microprofile/Dockerfile
+++ b/TomEE-9.0/jre17/Temurin/ubuntu/microprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-focal
+FROM eclipse-temurin:17-jre-jammy
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/TomEE-9.0/jre17/Temurin/ubuntu/plume/Dockerfile
+++ b/TomEE-9.0/jre17/Temurin/ubuntu/plume/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-focal
+FROM eclipse-temurin:17-jre-jammy
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/TomEE-9.0/jre17/Temurin/ubuntu/plus/Dockerfile
+++ b/TomEE-9.0/jre17/Temurin/ubuntu/plus/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-focal
+FROM eclipse-temurin:17-jre-jammy
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee

--- a/TomEE-9.0/jre17/Temurin/ubuntu/webprofile/Dockerfile
+++ b/TomEE-9.0/jre17/Temurin/ubuntu/webprofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-focal
+FROM eclipse-temurin:17-jre-jammy
 
 ENV PATH /usr/local/tomee/bin:$PATH
 RUN mkdir -p /usr/local/tomee


### PR DESCRIPTION
Update from _focal_ to _jammy_ for _Ubuntu_ based _Temurin_ and _Semeru_ images without additional changes.

I've done this for the TomEE 9.0 releases only (tested on top of v9.0.0 bump #73) to not mess up any stable images. Should work for older releases, too.

Built and started some images without any issues.

<details>
  <summary>Build log for 9.0.0-jre17-Temurin-ubuntu-webprofile</summary>

```
Sending build context to Docker daemon  5.632kB

Step 1/11 : FROM eclipse-temurin:17-jre-jammy
 ---> 5e2265f6166a
Step 2/11 : ENV PATH /usr/local/tomee/bin:$PATH
 ---> Running in 203ccdc05d79
Removing intermediate container 203ccdc05d79
 ---> 4f6ae59d35e4
Step 3/11 : RUN mkdir -p /usr/local/tomee
 ---> Running in 7a8b3bf62d44
Removing intermediate container 7a8b3bf62d44
 ---> cb8431c2c8e1
Step 4/11 : WORKDIR /usr/local/tomee
 ---> Running in c03ee9243f4e
Removing intermediate container c03ee9243f4e
 ---> 883693064d85
Step 5/11 : RUN apt-get update   && apt-get install -y  gpg   && rm -rf /var/lib/apt/lists/*
 ---> Running in 56e87611870f
Get:1 http://archive.ubuntu.com/ubuntu jammy InRelease [270 kB]
Get:2 http://security.ubuntu.com/ubuntu jammy-security InRelease [110 kB]
Get:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease [114 kB]
Get:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease [99.8 kB]
Get:5 http://archive.ubuntu.com/ubuntu jammy/universe amd64 Packages [17.5 MB]
Get:6 http://archive.ubuntu.com/ubuntu jammy/restricted amd64 Packages [164 kB]
Get:7 http://archive.ubuntu.com/ubuntu jammy/main amd64 Packages [1,792 kB]
Get:8 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages [736 kB]
Get:9 http://archive.ubuntu.com/ubuntu jammy/multiverse amd64 Packages [266 kB]
Get:10 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 Packages [994 kB]
Get:11 http://archive.ubuntu.com/ubuntu jammy-updates/multiverse amd64 Packages [8,978 B]
Get:12 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages [1,051 kB]
Get:13 http://archive.ubuntu.com/ubuntu jammy-updates/restricted amd64 Packages [730 kB]
Get:14 http://archive.ubuntu.com/ubuntu jammy-backports/universe amd64 Packages [7,286 B]
Get:15 http://archive.ubuntu.com/ubuntu jammy-backports/main amd64 Packages [3,520 B]
Get:16 http://security.ubuntu.com/ubuntu jammy-security/multiverse amd64 Packages [4,732 B]
Get:17 http://security.ubuntu.com/ubuntu jammy-security/universe amd64 Packages [789 kB]
Get:18 http://security.ubuntu.com/ubuntu jammy-security/restricted amd64 Packages [681 kB]
Fetched 25.3 MB in 2s (12.8 MB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  dirmngr gnupg gnupg-l10n gnupg-utils gpg-agent gpg-wks-client gpg-wks-server
  gpgconf gpgsm libassuan0 libksba8 libnpth0 libreadline8 libsqlite3-0
  pinentry-curses readline-common
Suggested packages:
  dbus-user-session libpam-systemd pinentry-gnome3 tor parcimonie xloadimage
  scdaemon pinentry-doc readline-doc
The following NEW packages will be installed:
  dirmngr gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client
  gpg-wks-server gpgconf gpgsm libassuan0 libksba8 libnpth0 libreadline8
  libsqlite3-0 pinentry-curses readline-common
0 upgraded, 17 newly installed, 0 to remove and 5 not upgraded.
Need to get 3,157 kB of archives.
After this operation, 8,031 kB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu jammy/main amd64 readline-common all 8.1.2-1 [53.5 kB]
Get:2 http://archive.ubuntu.com/ubuntu jammy/main amd64 libreadline8 amd64 8.1.2-1 [153 kB]
Get:3 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libsqlite3-0 amd64 3.37.2-2ubuntu0.1 [641 kB]
Get:4 http://archive.ubuntu.com/ubuntu jammy/main amd64 libassuan0 amd64 2.5.5-1build1 [38.2 kB]
Get:5 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 gpgconf amd64 2.2.27-3ubuntu2.1 [94.2 kB]
Get:6 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libksba8 amd64 1.6.0-2ubuntu0.2 [119 kB]
Get:7 http://archive.ubuntu.com/ubuntu jammy/main amd64 libnpth0 amd64 1.6-3build2 [8,664 B]
Get:8 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 dirmngr amd64 2.2.27-3ubuntu2.1 [293 kB]
Get:9 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 gnupg-l10n all 2.2.27-3ubuntu2.1 [54.4 kB]
Get:10 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 gnupg-utils amd64 2.2.27-3ubuntu2.1 [308 kB]
Get:11 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 gpg amd64 2.2.27-3ubuntu2.1 [519 kB]
Get:12 http://archive.ubuntu.com/ubuntu jammy/main amd64 pinentry-curses amd64 1.1.1-1build2 [34.4 kB]
Get:13 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 gpg-agent amd64 2.2.27-3ubuntu2.1 [209 kB]
Get:14 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 gpg-wks-client amd64 2.2.27-3ubuntu2.1 [62.7 kB]
Get:15 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 gpg-wks-server amd64 2.2.27-3ubuntu2.1 [57.5 kB]
Get:16 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 gpgsm amd64 2.2.27-3ubuntu2.1 [197 kB]
Get:17 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 gnupg all 2.2.27-3ubuntu2.1 [315 kB]
[91mdebconf: delaying package configuration, since apt-utils is not installed
[0mFetched 3,157 kB in 0s (10.9 MB/s)
Selecting previously unselected package readline-common.
(Reading database ... 
(Reading database ... 5%
(Reading database ... 10%
(Reading database ... 15%
(Reading database ... 20%
(Reading database ... 25%
(Reading database ... 30%
(Reading database ... 35%
(Reading database ... 40%
(Reading database ... 45%
(Reading database ... 50%
(Reading database ... 55%
(Reading database ... 60%
(Reading database ... 65%
(Reading database ... 70%
(Reading database ... 75%
(Reading database ... 80%
(Reading database ... 85%
(Reading database ... 90%
(Reading database ... 95%
(Reading database ... 100%
(Reading database ... 7916 files and directories currently installed.)
Preparing to unpack .../00-readline-common_8.1.2-1_all.deb ...
Unpacking readline-common (8.1.2-1) ...
Selecting previously unselected package libreadline8:amd64.
Preparing to unpack .../01-libreadline8_8.1.2-1_amd64.deb ...
Unpacking libreadline8:amd64 (8.1.2-1) ...
Selecting previously unselected package libsqlite3-0:amd64.
Preparing to unpack .../02-libsqlite3-0_3.37.2-2ubuntu0.1_amd64.deb ...
Unpacking libsqlite3-0:amd64 (3.37.2-2ubuntu0.1) ...
Selecting previously unselected package libassuan0:amd64.
Preparing to unpack .../03-libassuan0_2.5.5-1build1_amd64.deb ...
Unpacking libassuan0:amd64 (2.5.5-1build1) ...
Selecting previously unselected package gpgconf.
Preparing to unpack .../04-gpgconf_2.2.27-3ubuntu2.1_amd64.deb ...
Unpacking gpgconf (2.2.27-3ubuntu2.1) ...
Selecting previously unselected package libksba8:amd64.
Preparing to unpack .../05-libksba8_1.6.0-2ubuntu0.2_amd64.deb ...
Unpacking libksba8:amd64 (1.6.0-2ubuntu0.2) ...
Selecting previously unselected package libnpth0:amd64.
Preparing to unpack .../06-libnpth0_1.6-3build2_amd64.deb ...
Unpacking libnpth0:amd64 (1.6-3build2) ...
Selecting previously unselected package dirmngr.
Preparing to unpack .../07-dirmngr_2.2.27-3ubuntu2.1_amd64.deb ...
Unpacking dirmngr (2.2.27-3ubuntu2.1) ...
Selecting previously unselected package gnupg-l10n.
Preparing to unpack .../08-gnupg-l10n_2.2.27-3ubuntu2.1_all.deb ...
Unpacking gnupg-l10n (2.2.27-3ubuntu2.1) ...
Selecting previously unselected package gnupg-utils.
Preparing to unpack .../09-gnupg-utils_2.2.27-3ubuntu2.1_amd64.deb ...
Unpacking gnupg-utils (2.2.27-3ubuntu2.1) ...
Selecting previously unselected package gpg.
Preparing to unpack .../10-gpg_2.2.27-3ubuntu2.1_amd64.deb ...
Unpacking gpg (2.2.27-3ubuntu2.1) ...
Selecting previously unselected package pinentry-curses.
Preparing to unpack .../11-pinentry-curses_1.1.1-1build2_amd64.deb ...
Unpacking pinentry-curses (1.1.1-1build2) ...
Selecting previously unselected package gpg-agent.
Preparing to unpack .../12-gpg-agent_2.2.27-3ubuntu2.1_amd64.deb ...
Unpacking gpg-agent (2.2.27-3ubuntu2.1) ...
Selecting previously unselected package gpg-wks-client.
Preparing to unpack .../13-gpg-wks-client_2.2.27-3ubuntu2.1_amd64.deb ...
Unpacking gpg-wks-client (2.2.27-3ubuntu2.1) ...
Selecting previously unselected package gpg-wks-server.
Preparing to unpack .../14-gpg-wks-server_2.2.27-3ubuntu2.1_amd64.deb ...
Unpacking gpg-wks-server (2.2.27-3ubuntu2.1) ...
Selecting previously unselected package gpgsm.
Preparing to unpack .../15-gpgsm_2.2.27-3ubuntu2.1_amd64.deb ...
Unpacking gpgsm (2.2.27-3ubuntu2.1) ...
Selecting previously unselected package gnupg.
Preparing to unpack .../16-gnupg_2.2.27-3ubuntu2.1_all.deb ...
Unpacking gnupg (2.2.27-3ubuntu2.1) ...
Setting up libksba8:amd64 (1.6.0-2ubuntu0.2) ...
Setting up libsqlite3-0:amd64 (3.37.2-2ubuntu0.1) ...
Setting up libnpth0:amd64 (1.6-3build2) ...
Setting up libassuan0:amd64 (2.5.5-1build1) ...
Setting up gnupg-l10n (2.2.27-3ubuntu2.1) ...
Setting up readline-common (8.1.2-1) ...
Setting up pinentry-curses (1.1.1-1build2) ...
Setting up libreadline8:amd64 (8.1.2-1) ...
Setting up gpgconf (2.2.27-3ubuntu2.1) ...
Setting up gpg (2.2.27-3ubuntu2.1) ...
Setting up gnupg-utils (2.2.27-3ubuntu2.1) ...
Setting up gpg-agent (2.2.27-3ubuntu2.1) ...
Setting up gpgsm (2.2.27-3ubuntu2.1) ...
Setting up dirmngr (2.2.27-3ubuntu2.1) ...
Setting up gpg-wks-server (2.2.27-3ubuntu2.1) ...
Setting up gpg-wks-client (2.2.27-3ubuntu2.1) ...
Setting up gnupg (2.2.27-3ubuntu2.1) ...
Processing triggers for libc-bin (2.35-0ubuntu3.1) ...
Removing intermediate container 56e87611870f
 ---> ad0403c51d5b
Step 6/11 : RUN set -xe;   for key in   9056B710F1E332780DE7AF34CBAEBE39A46C4CA1   F067B8140F5DD80E1D3B5D92318242FE9A0B1183   223D3A74B068ECA354DC385CE126833F9CF64915   DBCCD103B8B24F86FFAAB025C8BB472CD297D428   7A2744A8A9AAF063C23EB7868EBE7DBE8D050EEF   B8B301E6105DF628076BD92C5483E55897ABD9B9   FAA603D58B1BA4EDF65896D0ED340E0E6D545F97   A57DAF81C1B69921F4BA8723A8DE0A4DB863A7C1   82D8419BA697F0E7FB85916EE91287822FDB81B1   B7574789F5018690043E6DD9C212662E12F3E1DD   C23A3F6F595EBD0F960270CC997C8F1A5BE6E4C1   678F2D98F1FD9643811639FB622B8F2D043F71D8   BDD0BBEB753192957EFC5F896A62FC8EF17D8FEF   D11DF12CC2CA4894BDE638B967C1227A2678363C   C92604B0DEC5C62CFF5801E73D4683C24EDC64D1   626C542EDA7C113814B77AF09C04914D63645D20   3948829384B269D333CC5B98358807C52B4B0E23   B83D15E72253ED1104EB4FBBDAB472F0E5B8A431   ; do     gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "$key" ||     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ;   done
 ---> Running in d92d9711d9a1
[91m+ gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 9056B710F1E332780DE7AF34CBAEBE39A46C4CA1
[0m[91mgpg: directory '/root/.gnupg' created
[0m[91mgpg: keybox '/root/.gnupg/pubring.kbx' created
[0m[91mgpg: /root/.gnupg/trustdb.gpg: trustdb created
[0m[91mgpg: key CBAEBE39A46C4CA1: public key "Matt Hogstrom <hogstrom@apache.org>" imported
[0m[91mgpg: Total number processed: 1
gpg:               imported: 1
[0m[91m+ gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys F067B8140F5DD80E1D3B5D92318242FE9A0B1183
[0m[91mgpg: key 318242FE9A0B1183: public key "Jeremy Whitlock <jwhitlock@apache.org>" imported
[0m[91mgpg: Total number processed: 1
gpg:               imported: 1
[0m[91m+ gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 223D3A74B068ECA354DC385CE126833F9CF64915
[0m[91mgpg: key E126833F9CF64915: public key "Richard Kenneth McGuire (CODE SIGNING KEY) <rickmcguire@apache.org>" imported
[0m[91mgpg: Total number processed: 1
gpg:               imported: 1
[0m[91m+ gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys DBCCD103B8B24F86FFAAB025C8BB472CD297D428
[0m[91mgpg: key C8BB472CD297D428: public key "Jonathan Gallimore <jgallimore@apache.org>" imported
[0m[91mgpg: Total number processed: 1
gpg:               imported: 1
[0m[91m+ gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 7A2744A8A9AAF063C23EB7868EBE7DBE8D050EEF
[0m[91mgpg: key 8EBE7DBE8D050EEF: public key "Jarek Gawor (CODE SIGNING KEY) <gawor@apache.org>" imported
[0m[91mgpg: Total number processed: 1
gpg:               imported: 1
[0m[91m+ gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B8B301E6105DF628076BD92C5483E55897ABD9B9
[0m[91mgpg: key 5483E55897ABD9B9: public key "Jarek Gawor <gawor@apache.org>" imported
[0m[91mgpg: Total number processed: 1
gpg:               imported: 1
[0m[91m+ gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys FAA603D58B1BA4EDF65896D0ED340E0E6D545F97
[0m[91mgpg: key ED340E0E6D545F97: public key "Andy Gumbrecht (TomEE Code Signing) <agumbrecht@tomitribe.com>" imported
[0m[91mgpg: Total number processed: 1
gpg:               imported: 1
[0m[91m+ gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys A57DAF81C1B69921F4BA8723A8DE0A4DB863A7C1
[0m[91mgpg: key A8DE0A4DB863A7C1: public key "Romain Manni-Bucau <rmannibucau@tomitribe.com>" imported
[0m[91mgpg: Total number processed: 1
gpg:               imported: 1
[0m[91m+ gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 82D8419BA697F0E7FB85916EE91287822FDB81B1
[0m[91mgpg: key E91287822FDB81B1: public key "Mark Struberg (Apache) <struberg@apache.org>" imported
[0m[91mgpg: Total number processed: 1
gpg:               imported: 1
[0m[91m+ gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B7574789F5018690043E6DD9C212662E12F3E1DD
[0m[91mgpg: key C212662E12F3E1DD: public key "David Blevins <dblevins@apache.org>" imported
[0m[91mgpg: Total number processed: 1
gpg:               imported: 1
[0m[91m+ gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C23A3F6F595EBD0F960270CC997C8F1A5BE6E4C1
[0m[91mgpg: key 997C8F1A5BE6E4C1: public key "Xu Hai Hong (Ivan Xu @ Geronimo) <xhhsld@gmail.com>" imported
[0m[91mgpg: Total number processed: 1
gpg:               imported: 1
[0m[91m+ gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 678F2D98F1FD9643811639FB622B8F2D043F71D8
[0m[91mgpg: key 622B8F2D043F71D8: public key "Jean-Louis Monteiro (CODE SIGNING KEY) <jlmonteiro@apache.org>" imported
[0m[91mgpg: Total number processed: 1
gpg:               imported: 1
[0m[91m+ gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys BDD0BBEB753192957EFC5F896A62FC8EF17D8FEF
[0m[91mgpg: key 6A62FC8EF17D8FEF: public key "Romain Manni-Bucau <rmannibucau@apache.org>" imported
[0m[91mgpg: Total number processed: 1
gpg:               imported: 1
[0m[91m+ gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D11DF12CC2CA4894BDE638B967C1227A2678363C
[0m[91mgpg: key 67C1227A2678363C: public key "Romain Manni-Bucau <rmannibucau@apache.org>" imported
[0m[91mgpg: Total number processed: 1
gpg:               imported: 1
[0m[91m+ gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C92604B0DEC5C62CFF5801E73D4683C24EDC64D1
[0m[91mgpg: key 3D4683C24EDC64D1: public key "Roberto Cortez (Apache Signing Key) <radcortez@yahoo.com>" imported
[0m[91mgpg: Total number processed: 1
gpg:               imported: 1
[0m[91m+ gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 626C542EDA7C113814B77AF09C04914D63645D20
[0m[91mgpg: key 9C04914D63645D20: public key "David Blevins <dblevins@tomitribe.com>" imported
[0m[91mgpg: Total number processed: 1
gpg:               imported: 1
[0m[91m+ gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3948829384B269D333CC5B98358807C52B4B0E23
[0m[91mgpg: key 358807C52B4B0E23: public key "Jean-Louis Monteiro (CODE SIGNING KEY) <jlmonteiro@apache.org>" imported
[0m[91mgpg: Total number processed: 1
gpg:               imported: 1
[0m[91m+ gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B83D15E72253ED1104EB4FBBDAB472F0E5B8A431
[0m[91mgpg: key DAB472F0E5B8A431: public key "Richard Zowalla (Code Signing Key) <rzo1@apache.org>" imported
[0m[91mgpg: Total number processed: 1
gpg:               imported: 1
[0mRemoving intermediate container d92d9711d9a1
 ---> ae1b42dff677
Step 7/11 : ENV TOMEE_VER 9.0.0
 ---> Running in 14df9e107cb7
Removing intermediate container 14df9e107cb7
 ---> 7e393dc3f99f
Step 8/11 : ENV TOMEE_BUILD webprofile
 ---> Running in 25c371500b89
Removing intermediate container 25c371500b89
 ---> 02c1e0120f24
Step 9/11 : RUN set -x   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.asc -o tomee.tar.gz.asc   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz.sha512 -o tomee.tar.gz.sha512   && curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-${TOMEE_VER}/apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz -o apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz   && gpg --batch --verify tomee.tar.gz.asc apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz   && echo `cat tomee.tar.gz.sha512` | sha512sum -c -   && tar -zxf apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz   && mv apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}/* /usr/local/tomee   && rm apache-tomee-${TOMEE_VER}-${TOMEE_BUILD}.tar.gz   && rm -Rf apache-tomee-${TOMEE_BUILD}-${TOMEE_VER}   && rm bin/*.bat   && rm bin/*.exe   && rm bin/*.tar.gz*   && rm tomee.tar.gz.asc   && rm tomee.tar.gz*
 ---> Running in 8af3780dd09a
[91m+ curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-9.0.0/apache-tomee-9.0.0-webprofile.tar.gz.asc -o tomee.tar.gz.asc
[0m[91m  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0[0m[91m
100   833  100   833    0     0   2377      0 --:--:-- --:--:-- --:--:--  23[0m[91m80
[0m[91m+ curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-9.0.0/apache-tomee-9.0.0-webprofile.tar.gz.sha512 -o tomee.tar.gz.sha512
[0m[91m  % Total    % Received % Xferd  Average Speed   Tim[0m[91me    Time     Time  Current[0m[91m
               [0m[91m      [0m[91m    [0m[91m     [0m[91m   [0m[91mDloa[0m[91md  [0m[91mUpload   [0m[91mTota[0m[91ml   [0m[91mSpen[0m[91mt  [0m[91m  Lef[0m[91mt  S[0m[91mpeed
[0m[91m
  0     0 [0m[91m   0     0   [0m[91m 0     0 [0m[91m     [0m[91m0    [0m[91m  0 --:--:-- -[0m[91m-:--:-- --:--:[0m[91m--     0[0m[91m
  0     0    0     0    0     0      0      0 [0m[91m--:--:-- --:--:-- --[0m[91m:--:--     0[0m[91m
100   167  100   167    0     0    488      0 --:--:-- --:--:-- --:--[0m[91m:--   488
[0m[91m+ curl -fSL https://dist.apache.org/repos/dist/release/tomee/tomee-9.0.0/apache-tomee-9.0.0-webprofile.tar.gz -o apache-tomee-9.0.0-webprofile.tar.gz
[0m[91m  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current[0m[91m
                  [0m[91m         [0m[91m      Dload [0m[91m Up[0m[91mloa[0m[91md   [0m[91mTotal [0m[91m  S[0m[91mpen[0m[91mt    Left  Speed
[0m[91m
  0     0    0    [0m[91m 0    0[0m[91m  [0m[91m   0  [0m[91m    0[0m[91m    [0m[91m  0 -[0m[91m-:--:[0m[91m-- --:[0m[91m--:-[0m[91m- --[0m[91m:--:-[0m[91m-     [0m[91m0[0m[91m
  1 52.9M    1  976k    0     0  1121k      0  0:00[0m[91m:48 --:--:--  0:00:48 1120k[0m[91m
 19 52.9M   19 10.1M    0     0  5541k      0  0:00:[0m[91m09  0:00:01  0:00:08 5540k[0m[91m
 36 52.9M   36 19.1M    0     0  6810k      0  0:0[0m[91m0:07  0:00:02 [0m[91m 0[0m[91m:00:05 6809k[0m[91m
 54 52.9M   [0m[91m54 28.7M    0     0  7[0m[91m610k [0m[91m     0  0:00:07[0m[91m  0:00:[0m[91m03  [0m[91m0:00:04 7[0m[91m609k[0m[91m
 72 52.9M   72[0m[91m [0m[91m38.2M    0     0[0m[91m  7953[0m[91mk      0  0:00[0m[91m:06[0m[91m  0:[0m[91m00:04[0m[91m  0:0[0m[91m0:02 7952k[0m[91m
 86 52.9M   86 45.9M    0     0  8013k      0  0:00:06  0:00:05  0:00:01 9214k[0m[91m
100 52.9M  100 52.9M    0     0  80[0m[91m11k      0  0:00:06  0:00:06 --:[0m[91m--:-- 8959k
[0m[91m+ gpg --batch --verify tomee.tar.gz.asc apache-tomee-9.0.0-webprofile.tar.gz
[0m[91mgpg: Signature made Tue 03 Jan 2023 08:44:45 AM UTC
gpg:                using RSA key 3948829384B269D333CC5B98358807C52B4B0E23
[0m[91mgpg: Good signature from "Jean-Louis Monteiro (CODE SIGNING KEY) <jlmonteiro@apache.org>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 3948 8293 84B2 69D3 33CC  5B98 3588 07C5 2B4B 0E23
[0m[91m+ [0m[91mcat tomee.tar.gz.sha512
[0m[91m+ [0m[91msha512sum -c -
[0m[91m+ echo d958065c3ec9d0b30b09909c10f2f689a36fc10298cebee07f64fdfda76161b862783a91e8a334ada0f6faceea898f4990ead02f5e91b2b9fd58839e48b499b3 apache-tomee-9.0.0-webprofile.tar.gz
[0mapache-tomee-9.0.0-webprofile.tar.gz: OK
[91m+ tar -zxf apache-tomee-9.0.0-webprofile.tar.gz
[0m[91m+ mv apache-tomee-webprofile-9.0.0/BUILDING.txt apache-tomee-webprofile-9.0.0/CONTRIBUTING.md apache-tomee-webprofile-9.0.0/LICENSE apache-tomee-webprofile-9.0.0/NOTICE apache-tomee-webprofile-9.0.0/README.md apache-tomee-webprofile-9.0.0/RELEASE-NOTES apache-tomee-webprofile-9.0.0/RUNNING.txt apache-tomee-webprofile-9.0.0/bin apache-tomee-webprofile-9.0.0/conf apache-tomee-webprofile-9.0.0/lib apache-tomee-webprofile-9.0.0/logs apache-tomee-webprofile-9.0.0/temp apache-tomee-webprofile-9.0.0/webapps apache-tomee-webprofile-9.0.0/work /usr/local/tomee
[0m[91m+ rm apache-tomee-9.0.0-webprofile.tar.gz
[0m[91m+ rm -Rf apache-tomee-webprofile-9.0.0
[0m[91m+ rm bin/catalina.bat bin/ciphers.bat bin/configtest.bat bin/digest.bat bin/makebase.bat bin/migrate.bat bin/service.bat bin/service.install.as.admin.bat bin/service.remove.as.admin.bat bin/setclasspath.bat bin/shutdown.bat bin/startup.bat bin/tomee.bat bin/tool-wrapper.bat[0m[91m bin/version.bat
[0m[91m+ rm bin/TomEE.amd64.exe bin/TomEE.exe bin/TomEE.x86.exe
[0m[91m+ rm bin/commons-daemon-native.tar.gz bin/tomcat-native.tar.gz
[0m[91m+ rm tomee.tar.gz.asc
[0m[91m+ rm tomee.tar.gz.sha512
[0mRemoving intermediate container 8af3780dd09a
 ---> 096b636860c7
Step 10/11 : EXPOSE 8080
 ---> Running in 4d44cf2e72dc
Removing intermediate container 4d44cf2e72dc
 ---> 16f5b5718bf9
Step 11/11 : CMD ["catalina.sh", "run"]
 ---> Running in e217ee434999
Removing intermediate container e217ee434999
 ---> c319da2c7ab8
Successfully built c319da2c7ab8
Successfully tagged tomee:9.0.0-jre17-Temurin-ubuntu-webprofile
```

</details>


<details>
  <summary>Startup log for 9.0.0-jre17-Temurin-ubuntu-webprofile</summary>
  
```
Using CATALINA_BASE:   /usr/local/tomee
Using CATALINA_HOME:   /usr/local/tomee
Using CATALINA_TMPDIR: /usr/local/tomee/temp
Using JRE_HOME:        /opt/java/openjdk
Using CLASSPATH:       /usr/local/tomee/bin/bootstrap.jar:/usr/local/tomee/bin/tomcat-juli.jar
Using CATALINA_OPTS:   
NOTE: Picked up JDK_JAVA_OPTIONS:  --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED
20-Jan-2023 08:57:04.274 INFO [main] jdk.internal.reflect.NativeMethodAccessorImpl.invoke Server version name:   Apache Tomcat (TomEE)/10.0.27 (9.0.0)
20-Jan-2023 08:57:04.275 INFO [main] jdk.internal.reflect.NativeMethodAccessorImpl.invoke Server built:          Oct 3 2022 14:18:31 UTC
20-Jan-2023 08:57:04.275 INFO [main] jdk.internal.reflect.NativeMethodAccessorImpl.invoke Server version number: 10.0.27.0
20-Jan-2023 08:57:04.275 INFO [main] jdk.internal.reflect.NativeMethodAccessorImpl.invoke OS Name:               Linux
20-Jan-2023 08:57:04.275 INFO [main] jdk.internal.reflect.NativeMethodAccessorImpl.invoke OS Version:            6.0.18-300.fc37.x86_64
20-Jan-2023 08:57:04.275 INFO [main] jdk.internal.reflect.NativeMethodAccessorImpl.invoke Architecture:          amd64
20-Jan-2023 08:57:04.275 INFO [main] jdk.internal.reflect.NativeMethodAccessorImpl.invoke Java Home:             /opt/java/openjdk
20-Jan-2023 08:57:04.275 INFO [main] jdk.internal.reflect.NativeMethodAccessorImpl.invoke JVM Version:           17.0.5+8
20-Jan-2023 08:57:04.275 INFO [main] jdk.internal.reflect.NativeMethodAccessorImpl.invoke JVM Vendor:            Eclipse Adoptium
20-Jan-2023 08:57:04.275 INFO [main] jdk.internal.reflect.NativeMethodAccessorImpl.invoke CATALINA_BASE:         /usr/local/tomee
20-Jan-2023 08:57:04.275 INFO [main] jdk.internal.reflect.NativeMethodAccessorImpl.invoke CATALINA_HOME:         /usr/local/tomee
20-Jan-2023 08:57:04.290 INFO [main] jdk.internal.reflect.NativeMethodAccessorImpl.invoke Command line argument: --add-opens=java.base/java.lang=ALL-UNNAMED
20-Jan-2023 08:57:04.290 INFO [main] jdk.internal.reflect.NativeMethodAccessorImpl.invoke Command line argument: --add-opens=java.base/java.io=ALL-UNNAMED
20-Jan-2023 08:57:04.290 INFO [main] jdk.internal.reflect.NativeMethodAccessorImpl.invoke Command line argument: --add-opens=java.base/java.util=ALL-UNNAMED
20-Jan-2023 08:57:04.290 INFO [main] jdk.internal.reflect.NativeMethodAccessorImpl.invoke Command line argument: --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
20-Jan-2023 08:57:04.290 INFO [main] jdk.internal.reflect.NativeMethodAccessorImpl.invoke Command line argument: --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED
20-Jan-2023 08:57:04.290 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Command line argument: -Djava.util.logging.config.file=/usr/local/tomee/conf/logging.properties
20-Jan-2023 08:57:04.291 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Command line argument: -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
20-Jan-2023 08:57:04.291 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Command line argument: -javaagent:/usr/local/tomee/lib/openejb-javaagent.jar
20-Jan-2023 08:57:04.291 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Command line argument: -Djdk.tls.ephemeralDHKeySize=2048
20-Jan-2023 08:57:04.291 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Command line argument: -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
20-Jan-2023 08:57:04.291 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Command line argument: -Dorg.apache.catalina.security.SecurityListener.UMASK=0027
20-Jan-2023 08:57:04.291 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Command line argument: -Dignore.endorsed.dirs=
20-Jan-2023 08:57:04.291 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Command line argument: -Dcatalina.base=/usr/local/tomee
20-Jan-2023 08:57:04.291 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Command line argument: -Dcatalina.home=/usr/local/tomee
20-Jan-2023 08:57:04.291 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Command line argument: -Djava.io.tmpdir=/usr/local/tomee/temp
20-Jan-2023 08:57:04.292 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke The Apache Tomcat Native library which allows using OpenSSL was not found on the java.library.path: [/usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib]
20-Jan-2023 08:57:04.523 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Initializing ProtocolHandler ["http-nio-8080"]
20-Jan-2023 08:57:04.653 INFO [main] org.apache.openejb.util.OptionsLog.info Using 'openejb.jdbc.datasource-creator=org.apache.tomee.jdbc.TomEEDataSourceCreator'
20-Jan-2023 08:57:04.708 INFO [main] org.apache.openejb.OpenEJB$Instance.<init> ********************************************************************************
20-Jan-2023 08:57:04.709 INFO [main] org.apache.openejb.OpenEJB$Instance.<init> OpenEJB http://tomee.apache.org/
20-Jan-2023 08:57:04.709 INFO [main] org.apache.openejb.OpenEJB$Instance.<init> Startup: Fri Jan 20 08:57:04 UTC 2023
20-Jan-2023 08:57:04.709 INFO [main] org.apache.openejb.OpenEJB$Instance.<init> Copyright 1999-2021 (C) Apache TomEE Project, All Rights Reserved.
20-Jan-2023 08:57:04.709 INFO [main] org.apache.openejb.OpenEJB$Instance.<init> Version: 9.0.0
20-Jan-2023 08:57:04.709 INFO [main] org.apache.openejb.OpenEJB$Instance.<init> Build date: 20230103
20-Jan-2023 08:57:04.709 INFO [main] org.apache.openejb.OpenEJB$Instance.<init> Build time: 09:35
20-Jan-2023 08:57:04.709 INFO [main] org.apache.openejb.OpenEJB$Instance.<init> ********************************************************************************
20-Jan-2023 08:57:04.709 INFO [main] org.apache.openejb.OpenEJB$Instance.<init> openejb.home = /usr/local/tomee
20-Jan-2023 08:57:04.709 INFO [main] org.apache.openejb.OpenEJB$Instance.<init> openejb.base = /usr/local/tomee
20-Jan-2023 08:57:04.710 INFO [main] org.apache.openejb.cdi.CdiBuilder.initializeOWB Created new singletonService org.apache.openejb.cdi.ThreadSingletonServiceImpl@3fc79729
20-Jan-2023 08:57:04.712 INFO [main] org.apache.openejb.cdi.CdiBuilder.initializeOWB Succeeded in installing singleton service
20-Jan-2023 08:57:04.728 INFO [main] org.apache.openejb.config.ConfigurationFactory.init TomEE configuration file is '/usr/local/tomee/conf/tomee.xml'
20-Jan-2023 08:57:04.750 INFO [main] org.apache.openejb.config.ConfigurationFactory.configureService Configuring Service(id=Tomcat Security Service, type=SecurityService, provider-id=Tomcat Security Service)
20-Jan-2023 08:57:04.751 INFO [main] org.apache.openejb.config.ConfigurationFactory.configureService Configuring Service(id=Default Transaction Manager, type=TransactionManager, provider-id=Default Transaction Manager)
20-Jan-2023 08:57:04.753 INFO [main] org.apache.openejb.util.OptionsLog.info Using 'openejb.deployments.classpath=false'
20-Jan-2023 08:57:04.755 INFO [main] org.apache.openejb.assembler.classic.Assembler.createRecipe Creating TransactionManager(id=Default Transaction Manager)
20-Jan-2023 08:57:04.786 INFO [main] org.apache.openejb.assembler.classic.Assembler.createRecipe Creating SecurityService(id=Tomcat Security Service)
20-Jan-2023 08:57:04.853 INFO [main] org.apache.openejb.server.ServiceManager.initServer Creating ServerService(id=cxf)
20-Jan-2023 08:57:04.997 INFO [main] org.apache.openejb.server.ServiceManager.initServer Creating ServerService(id=cxf-rs)
20-Jan-2023 08:57:05.012 INFO [main] org.apache.openejb.server.SimpleServiceManager.start   ** Bound Services **
20-Jan-2023 08:57:05.012 INFO [main] org.apache.openejb.server.SimpleServiceManager.printRow   NAME                 IP              PORT  
20-Jan-2023 08:57:05.012 INFO [main] org.apache.openejb.server.SimpleServiceManager.start -------
20-Jan-2023 08:57:05.012 INFO [main] org.apache.openejb.server.SimpleServiceManager.start Ready!
20-Jan-2023 08:57:05.012 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Server initialization in [899] milliseconds
20-Jan-2023 08:57:05.034 INFO [main] org.apache.tomee.catalina.OpenEJBNamingContextListener.bindResource Importing a Tomcat Resource with id 'UserDatabase' of type 'org.apache.catalina.UserDatabase'.
20-Jan-2023 08:57:05.034 INFO [main] org.apache.openejb.assembler.classic.Assembler.createRecipe Creating Resource(id=UserDatabase)
20-Jan-2023 08:57:05.044 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Starting service [Catalina]
20-Jan-2023 08:57:05.044 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Starting Servlet engine: [Apache Tomcat (TomEE)/10.0.27 (9.0.0)]
20-Jan-2023 08:57:05.051 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Deploying web application directory [/usr/local/tomee/webapps/ROOT]
20-Jan-2023 08:57:05.056 INFO [main] org.apache.tomee.catalina.TomcatWebAppBuilder.init ------------------------- localhost -> /
20-Jan-2023 08:57:05.157 INFO [main] org.apache.openejb.config.ConfigurationFactory.configureApplication Configuring enterprise application: /usr/local/tomee/webapps/ROOT
20-Jan-2023 08:57:05.198 INFO [main] org.apache.openejb.config.AppInfoBuilder.build Enterprise application "/usr/local/tomee/webapps/ROOT" loaded.
20-Jan-2023 08:57:05.206 INFO [main] org.apache.openejb.assembler.classic.Assembler.createApplication Assembling app: /usr/local/tomee/webapps/ROOT
20-Jan-2023 08:57:05.274 INFO [main] org.apache.openejb.assembler.classic.ValidatorBuilder.getConfig Ignoring XML Configuration for validator org.apache.bval.jsr.ConfigurationImpl
20-Jan-2023 08:57:05.297 INFO [main] org.apache.openejb.assembler.classic.Assembler.createApplication Deployed Application(path=/usr/local/tomee/webapps/ROOT)
20-Jan-2023 08:57:05.367 INFO [main] org.apache.myfaces.ee.MyFacesContainerInitializer.onStartup Using org.apache.myfaces.ee.MyFacesContainerInitializer
20-Jan-2023 08:57:05.413 INFO [main] org.apache.jasper.servlet.TldScanner.scanJars At least one JAR was scanned for TLDs yet contained no TLDs. Enable debug logging for this logger for a complete list of JARs that were scanned but no TLDs were found in them. Skipping unneeded JARs during scanning can improve startup time and JSP compilation time.
20-Jan-2023 08:57:05.460 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Deployment of web application directory [/usr/local/tomee/webapps/ROOT] has finished in [409] ms
20-Jan-2023 08:57:05.460 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Deploying web application directory [/usr/local/tomee/webapps/docs]
20-Jan-2023 08:57:05.460 INFO [main] org.apache.tomee.catalina.TomcatWebAppBuilder.init ------------------------- localhost -> /docs
20-Jan-2023 08:57:05.469 INFO [main] org.apache.openejb.config.ConfigurationFactory.configureApplication Configuring enterprise application: /usr/local/tomee/webapps/docs
20-Jan-2023 08:57:05.472 INFO [main] org.apache.openejb.config.AppInfoBuilder.build Enterprise application "/usr/local/tomee/webapps/docs" loaded.
20-Jan-2023 08:57:05.472 INFO [main] org.apache.openejb.assembler.classic.Assembler.createApplication Assembling app: /usr/local/tomee/webapps/docs
20-Jan-2023 08:57:05.475 INFO [main] org.apache.openejb.assembler.classic.ValidatorBuilder.getConfig Ignoring XML Configuration for validator org.apache.bval.jsr.ConfigurationImpl
20-Jan-2023 08:57:05.477 INFO [main] org.apache.openejb.assembler.classic.Assembler.createApplication Deployed Application(path=/usr/local/tomee/webapps/docs)
20-Jan-2023 08:57:05.490 INFO [main] org.apache.myfaces.ee.MyFacesContainerInitializer.onStartup Using org.apache.myfaces.ee.MyFacesContainerInitializer
20-Jan-2023 08:57:05.498 INFO [main] org.apache.jasper.servlet.TldScanner.scanJars At least one JAR was scanned for TLDs yet contained no TLDs. Enable debug logging for this logger for a complete list of JARs that were scanned but no TLDs were found in them. Skipping unneeded JARs during scanning can improve startup time and JSP compilation time.
20-Jan-2023 08:57:05.504 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Deployment of web application directory [/usr/local/tomee/webapps/docs] has finished in [44] ms
20-Jan-2023 08:57:05.504 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Deploying web application directory [/usr/local/tomee/webapps/host-manager]
20-Jan-2023 08:57:05.506 INFO [main] org.apache.tomee.catalina.TomcatWebAppBuilder.init ------------------------- localhost -> /host-manager
20-Jan-2023 08:57:05.524 INFO [main] org.apache.openejb.config.ConfigurationFactory.configureApplication Configuring enterprise application: /usr/local/tomee/webapps/host-manager
20-Jan-2023 08:57:05.528 INFO [main] org.apache.openejb.config.AppInfoBuilder.build Enterprise application "/usr/local/tomee/webapps/host-manager" loaded.
20-Jan-2023 08:57:05.529 INFO [main] org.apache.openejb.assembler.classic.Assembler.createApplication Assembling app: /usr/local/tomee/webapps/host-manager
20-Jan-2023 08:57:05.532 INFO [main] org.apache.openejb.assembler.classic.ValidatorBuilder.getConfig Ignoring XML Configuration for validator org.apache.bval.jsr.ConfigurationImpl
20-Jan-2023 08:57:05.534 INFO [main] org.apache.tomee.catalina.TomcatWebAppBuilder.deployWebApps using context file /usr/local/tomee/webapps/host-manager/META-INF/context.xml
20-Jan-2023 08:57:05.535 INFO [main] org.apache.openejb.assembler.classic.Assembler.createApplication Deployed Application(path=/usr/local/tomee/webapps/host-manager)
20-Jan-2023 08:57:05.550 INFO [main] org.apache.myfaces.ee.MyFacesContainerInitializer.onStartup Using org.apache.myfaces.ee.MyFacesContainerInitializer
20-Jan-2023 08:57:05.559 INFO [main] org.apache.jasper.servlet.TldScanner.scanJars At least one JAR was scanned for TLDs yet contained no TLDs. Enable debug logging for this logger for a complete list of JARs that were scanned but no TLDs were found in them. Skipping unneeded JARs during scanning can improve startup time and JSP compilation time.
20-Jan-2023 08:57:05.569 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Deployment of web application directory [/usr/local/tomee/webapps/host-manager] has finished in [65] ms
20-Jan-2023 08:57:05.569 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Deploying web application directory [/usr/local/tomee/webapps/manager]
20-Jan-2023 08:57:05.570 INFO [main] org.apache.tomee.catalina.TomcatWebAppBuilder.init ------------------------- localhost -> /manager
20-Jan-2023 08:57:05.582 INFO [main] org.apache.openejb.config.ConfigurationFactory.configureApplication Configuring enterprise application: /usr/local/tomee/webapps/manager
20-Jan-2023 08:57:05.587 INFO [main] org.apache.openejb.config.AppInfoBuilder.build Enterprise application "/usr/local/tomee/webapps/manager" loaded.
20-Jan-2023 08:57:05.587 INFO [main] org.apache.openejb.assembler.classic.Assembler.createApplication Assembling app: /usr/local/tomee/webapps/manager
20-Jan-2023 08:57:05.590 INFO [main] org.apache.openejb.assembler.classic.ValidatorBuilder.getConfig Ignoring XML Configuration for validator org.apache.bval.jsr.ConfigurationImpl
20-Jan-2023 08:57:05.592 INFO [main] org.apache.tomee.catalina.TomcatWebAppBuilder.deployWebApps using context file /usr/local/tomee/webapps/manager/META-INF/context.xml
20-Jan-2023 08:57:05.592 INFO [main] org.apache.openejb.assembler.classic.Assembler.createApplication Deployed Application(path=/usr/local/tomee/webapps/manager)
20-Jan-2023 08:57:05.606 INFO [main] org.apache.myfaces.ee.MyFacesContainerInitializer.onStartup Using org.apache.myfaces.ee.MyFacesContainerInitializer
20-Jan-2023 08:57:05.614 INFO [main] org.apache.jasper.servlet.TldScanner.scanJars At least one JAR was scanned for TLDs yet contained no TLDs. Enable debug logging for this logger for a complete list of JARs that were scanned but no TLDs were found in them. Skipping unneeded JARs during scanning can improve startup time and JSP compilation time.
20-Jan-2023 08:57:05.619 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Deployment of web application directory [/usr/local/tomee/webapps/manager] has finished in [50] ms
20-Jan-2023 08:57:05.621 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Starting ProtocolHandler ["http-nio-8080"]
20-Jan-2023 08:57:05.627 INFO [main] jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke Server startup in [614] milliseconds
```

</details>