### PR TITLE
TomEE version bump to 8.0.14

### DIFF
--- a/TomEE-8.0/jre11/Semeru/ubuntu/microprofile/Dockerfile
+++ b/TomEE-8.0/jre11/Semeru/ubuntu/microprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre11/Semeru/ubuntu/plume/Dockerfile
+++ b/TomEE-8.0/jre11/Semeru/ubuntu/plume/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD plume
 
 RUN set -x \

--- a/TomEE-8.0/jre11/Semeru/ubuntu/plus/Dockerfile
+++ b/TomEE-8.0/jre11/Semeru/ubuntu/plus/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD plus
 
 RUN set -x \

--- a/TomEE-8.0/jre11/Semeru/ubuntu/webprofile/Dockerfile
+++ b/TomEE-8.0/jre11/Semeru/ubuntu/webprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre11/Temurin/alpine/microprofile/Dockerfile
+++ b/TomEE-8.0/jre11/Temurin/alpine/microprofile/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre11/Temurin/alpine/plume/Dockerfile
+++ b/TomEE-8.0/jre11/Temurin/alpine/plume/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD plume
 
 RUN set -x \

--- a/TomEE-8.0/jre11/Temurin/alpine/plus/Dockerfile
+++ b/TomEE-8.0/jre11/Temurin/alpine/plus/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD plus
 
 RUN set -x \

--- a/TomEE-8.0/jre11/Temurin/alpine/webprofile/Dockerfile
+++ b/TomEE-8.0/jre11/Temurin/alpine/webprofile/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre11/Temurin/ubuntu/microprofile/Dockerfile
+++ b/TomEE-8.0/jre11/Temurin/ubuntu/microprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre11/Temurin/ubuntu/plume/Dockerfile
+++ b/TomEE-8.0/jre11/Temurin/ubuntu/plume/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD plume
 
 RUN set -x \

--- a/TomEE-8.0/jre11/Temurin/ubuntu/plus/Dockerfile
+++ b/TomEE-8.0/jre11/Temurin/ubuntu/plus/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD plus
 
 RUN set -x \

--- a/TomEE-8.0/jre11/Temurin/ubuntu/webprofile/Dockerfile
+++ b/TomEE-8.0/jre11/Temurin/ubuntu/webprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre17/Semeru/ubuntu/microprofile/Dockerfile
+++ b/TomEE-8.0/jre17/Semeru/ubuntu/microprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre17/Semeru/ubuntu/plume/Dockerfile
+++ b/TomEE-8.0/jre17/Semeru/ubuntu/plume/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD plume
 
 RUN set -x \

--- a/TomEE-8.0/jre17/Semeru/ubuntu/plus/Dockerfile
+++ b/TomEE-8.0/jre17/Semeru/ubuntu/plus/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD plus
 
 RUN set -x \

--- a/TomEE-8.0/jre17/Semeru/ubuntu/webprofile/Dockerfile
+++ b/TomEE-8.0/jre17/Semeru/ubuntu/webprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre17/Temurin/alpine/microprofile/Dockerfile
+++ b/TomEE-8.0/jre17/Temurin/alpine/microprofile/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre17/Temurin/alpine/plume/Dockerfile
+++ b/TomEE-8.0/jre17/Temurin/alpine/plume/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD plume
 
 RUN set -x \

--- a/TomEE-8.0/jre17/Temurin/alpine/plus/Dockerfile
+++ b/TomEE-8.0/jre17/Temurin/alpine/plus/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD plus
 
 RUN set -x \

--- a/TomEE-8.0/jre17/Temurin/alpine/webprofile/Dockerfile
+++ b/TomEE-8.0/jre17/Temurin/alpine/webprofile/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre17/Temurin/ubuntu/microprofile/Dockerfile
+++ b/TomEE-8.0/jre17/Temurin/ubuntu/microprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre17/Temurin/ubuntu/plume/Dockerfile
+++ b/TomEE-8.0/jre17/Temurin/ubuntu/plume/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD plume
 
 RUN set -x \

--- a/TomEE-8.0/jre17/Temurin/ubuntu/plus/Dockerfile
+++ b/TomEE-8.0/jre17/Temurin/ubuntu/plus/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD plus
 
 RUN set -x \

--- a/TomEE-8.0/jre17/Temurin/ubuntu/webprofile/Dockerfile
+++ b/TomEE-8.0/jre17/Temurin/ubuntu/webprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre8/Temurin/alpine/microprofile/Dockerfile
+++ b/TomEE-8.0/jre8/Temurin/alpine/microprofile/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre8/Temurin/alpine/plume/Dockerfile
+++ b/TomEE-8.0/jre8/Temurin/alpine/plume/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD plume
 
 RUN set -x \

--- a/TomEE-8.0/jre8/Temurin/alpine/plus/Dockerfile
+++ b/TomEE-8.0/jre8/Temurin/alpine/plus/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD plus
 
 RUN set -x \

--- a/TomEE-8.0/jre8/Temurin/alpine/webprofile/Dockerfile
+++ b/TomEE-8.0/jre8/Temurin/alpine/webprofile/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre8/Temurin/ubuntu/microprofile/Dockerfile
+++ b/TomEE-8.0/jre8/Temurin/ubuntu/microprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD microprofile
 
 RUN set -x \

--- a/TomEE-8.0/jre8/Temurin/ubuntu/plume/Dockerfile
+++ b/TomEE-8.0/jre8/Temurin/ubuntu/plume/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD plume
 
 RUN set -x \

--- a/TomEE-8.0/jre8/Temurin/ubuntu/plus/Dockerfile
+++ b/TomEE-8.0/jre8/Temurin/ubuntu/plus/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD plus
 
 RUN set -x \

--- a/TomEE-8.0/jre8/Temurin/ubuntu/webprofile/Dockerfile
+++ b/TomEE-8.0/jre8/Temurin/ubuntu/webprofile/Dockerfile
@@ -52,7 +52,7 @@ RUN set -xe; \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV TOMEE_VER 8.0.13
+ENV TOMEE_VER 8.0.14
 ENV TOMEE_BUILD webprofile
 
 RUN set -x \


### PR DESCRIPTION
Trivial version bump from 8.0.13 to 8.0.14

Temurin and Semeru images built and started once without issues.

~If OpenJDK images get removed as part of #75, we might require little rebase here.~ (done)