### PR TITLE
chore: reduce attack surface and size for Docker image

### DIFF
--- a/TomEE-7.0/jre8/Temurin/ubuntu/plume/Dockerfile
+++ b/TomEE-7.0/jre8/Temurin/ubuntu/plume/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-7.0/jre8/Temurin/ubuntu/plus/Dockerfile
+++ b/TomEE-7.0/jre8/Temurin/ubuntu/plus/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-7.0/jre8/Temurin/ubuntu/webprofile/Dockerfile
+++ b/TomEE-7.0/jre8/Temurin/ubuntu/webprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-7.1/jre8/Temurin/ubuntu/microprofile/Dockerfile
+++ b/TomEE-7.1/jre8/Temurin/ubuntu/microprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-7.1/jre8/Temurin/ubuntu/plume/Dockerfile
+++ b/TomEE-7.1/jre8/Temurin/ubuntu/plume/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-7.1/jre8/Temurin/ubuntu/plus/Dockerfile
+++ b/TomEE-7.1/jre8/Temurin/ubuntu/plus/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-7.1/jre8/Temurin/ubuntu/webprofile/Dockerfile
+++ b/TomEE-7.1/jre8/Temurin/ubuntu/webprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-8.0/jre11/Semeru/ubuntu/microprofile/Dockerfile
+++ b/TomEE-8.0/jre11/Semeru/ubuntu/microprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-8.0/jre11/Semeru/ubuntu/plume/Dockerfile
+++ b/TomEE-8.0/jre11/Semeru/ubuntu/plume/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-8.0/jre11/Semeru/ubuntu/plus/Dockerfile
+++ b/TomEE-8.0/jre11/Semeru/ubuntu/plus/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-8.0/jre11/Semeru/ubuntu/webprofile/Dockerfile
+++ b/TomEE-8.0/jre11/Semeru/ubuntu/webprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-8.0/jre11/Temurin/ubuntu/microprofile/Dockerfile
+++ b/TomEE-8.0/jre11/Temurin/ubuntu/microprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-8.0/jre11/Temurin/ubuntu/plume/Dockerfile
+++ b/TomEE-8.0/jre11/Temurin/ubuntu/plume/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-8.0/jre11/Temurin/ubuntu/plus/Dockerfile
+++ b/TomEE-8.0/jre11/Temurin/ubuntu/plus/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-8.0/jre11/Temurin/ubuntu/webprofile/Dockerfile
+++ b/TomEE-8.0/jre11/Temurin/ubuntu/webprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-8.0/jre17/Semeru/ubuntu/microprofile/Dockerfile
+++ b/TomEE-8.0/jre17/Semeru/ubuntu/microprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-8.0/jre17/Semeru/ubuntu/plume/Dockerfile
+++ b/TomEE-8.0/jre17/Semeru/ubuntu/plume/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-8.0/jre17/Semeru/ubuntu/plus/Dockerfile
+++ b/TomEE-8.0/jre17/Semeru/ubuntu/plus/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-8.0/jre17/Semeru/ubuntu/webprofile/Dockerfile
+++ b/TomEE-8.0/jre17/Semeru/ubuntu/webprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-8.0/jre17/Temurin/ubuntu/microprofile/Dockerfile
+++ b/TomEE-8.0/jre17/Temurin/ubuntu/microprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-8.0/jre17/Temurin/ubuntu/plume/Dockerfile
+++ b/TomEE-8.0/jre17/Temurin/ubuntu/plume/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-8.0/jre17/Temurin/ubuntu/plus/Dockerfile
+++ b/TomEE-8.0/jre17/Temurin/ubuntu/plus/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-8.0/jre17/Temurin/ubuntu/webprofile/Dockerfile
+++ b/TomEE-8.0/jre17/Temurin/ubuntu/webprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-8.0/jre8/Temurin/ubuntu/microprofile/Dockerfile
+++ b/TomEE-8.0/jre8/Temurin/ubuntu/microprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-8.0/jre8/Temurin/ubuntu/plume/Dockerfile
+++ b/TomEE-8.0/jre8/Temurin/ubuntu/plume/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-8.0/jre8/Temurin/ubuntu/plus/Dockerfile
+++ b/TomEE-8.0/jre8/Temurin/ubuntu/plus/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-8.0/jre8/Temurin/ubuntu/webprofile/Dockerfile
+++ b/TomEE-8.0/jre8/Temurin/ubuntu/webprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-9.0/jre11/Semeru/ubuntu/microprofile/Dockerfile
+++ b/TomEE-9.0/jre11/Semeru/ubuntu/microprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-9.0/jre11/Semeru/ubuntu/plume/Dockerfile
+++ b/TomEE-9.0/jre11/Semeru/ubuntu/plume/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-9.0/jre11/Semeru/ubuntu/plus/Dockerfile
+++ b/TomEE-9.0/jre11/Semeru/ubuntu/plus/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-9.0/jre11/Semeru/ubuntu/webprofile/Dockerfile
+++ b/TomEE-9.0/jre11/Semeru/ubuntu/webprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-9.0/jre11/Temurin/ubuntu/microprofile/Dockerfile
+++ b/TomEE-9.0/jre11/Temurin/ubuntu/microprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-9.0/jre11/Temurin/ubuntu/plume/Dockerfile
+++ b/TomEE-9.0/jre11/Temurin/ubuntu/plume/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-9.0/jre11/Temurin/ubuntu/plus/Dockerfile
+++ b/TomEE-9.0/jre11/Temurin/ubuntu/plus/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-9.0/jre11/Temurin/ubuntu/webprofile/Dockerfile
+++ b/TomEE-9.0/jre11/Temurin/ubuntu/webprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-9.0/jre17/Semeru/ubuntu/microprofile/Dockerfile
+++ b/TomEE-9.0/jre17/Semeru/ubuntu/microprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-9.0/jre17/Semeru/ubuntu/plume/Dockerfile
+++ b/TomEE-9.0/jre17/Semeru/ubuntu/plume/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-9.0/jre17/Semeru/ubuntu/plus/Dockerfile
+++ b/TomEE-9.0/jre17/Semeru/ubuntu/plus/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-9.0/jre17/Semeru/ubuntu/webprofile/Dockerfile
+++ b/TomEE-9.0/jre17/Semeru/ubuntu/webprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-9.0/jre17/Temurin/ubuntu/microprofile/Dockerfile
+++ b/TomEE-9.0/jre17/Temurin/ubuntu/microprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-9.0/jre17/Temurin/ubuntu/plume/Dockerfile
+++ b/TomEE-9.0/jre17/Temurin/ubuntu/plume/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-9.0/jre17/Temurin/ubuntu/plus/Dockerfile
+++ b/TomEE-9.0/jre17/Temurin/ubuntu/plus/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \

--- a/TomEE-9.0/jre17/Temurin/ubuntu/webprofile/Dockerfile
+++ b/TomEE-9.0/jre17/Temurin/ubuntu/webprofile/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/local/tomee
 WORKDIR /usr/local/tomee
 
 RUN apt-get update \
-  && apt-get install -y  gpg \
+  && apt-get install -y --no-install-recommends gpg dirmngr \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -xe; \


### PR DESCRIPTION
Hi,

This pull request includes several small improvements for the Dockerfile, which should help improve the security of container and reduce the risk of potential attacks.

The following changes have been made:
- I added `--no-install-recommends` to remove unnecessary `apt` packages, that were not needed for the container's functionality. Not only can this change trim your image size but it also can also reduce the attack surface.
- `dirmngr` was added because it was needed for the `gpg` command.

I hope that you find them useful. Please let me know if you have any concerns.

Thank you.